### PR TITLE
feat: max daily consultation working as expected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -649,7 +648,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -673,7 +671,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2037,7 +2034,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4228,7 +4224,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",

--- a/src/app.js
+++ b/src/app.js
@@ -51,7 +51,9 @@ app.post('/api/register', async (req, res) => {
       password: hashedPassword
     })
 
-    await user.save()
+    await user.save();
+    console.log('User registered in DB:', user.email); // This will now show the actual email
+    res.status(201).json({ success: true, message: 'User registered!' });
 
     console.log('User registered in DB:', user.email)
     res.status(201).json({ success: true, message: 'User registered!' })

--- a/src/middleware/booking-validator.js
+++ b/src/middleware/booking-validator.js
@@ -1,13 +1,15 @@
+const Booking = require('../models/booking');
+
 const validateLecturerHours = async (req, res, next) => {
     try {
        
-        const { startTime, endTime, lecturerId, consultationId } = req.body;
+        const { startTime, endTime, lecturerId, consultationId, date } = req.body;
 
-        if (!startTime || !endTime || !lecturerId) {
+        if (!startTime || !endTime || !lecturerId || !date) {
             return res.status(400).json({
                 success: false,
-                message: "Validation failed: Missing required fields. Please provide lecturerId, startTime, and endTime."
-            });
+                message: "Validation failed: Missing required fields. Please provide lecturerId, date, startTime, and endTime."
+             });
         }
 
         const timeRegex = /^([01]\d|2[0-3]):([0-5]\d)$/;
@@ -19,7 +21,7 @@ const validateLecturerHours = async (req, res, next) => {
             });
         }
 
-        const lecturerStart = "09:00"; 
+        const lecturerStart = "09:00";
         const lecturerEnd = "16:00";
         
         if (startTime < lecturerStart || endTime > lecturerEnd) {
@@ -36,31 +38,50 @@ const validateLecturerHours = async (req, res, next) => {
             });
         }
 
-        
-        const maxCapacity = 5; 
-        const currentBookedStudents = 5; 
+        // Check capacity for this specific time slot
+        const maxCapacity = 5;
+        const currentBookedStudents = await Booking.countDocuments({
+            lecturerId,
+            date,
+            startTime,
+            endTime,
+            status: { $ne: 'canceled' }
+        });
         
         if (currentBookedStudents >= maxCapacity) {
             return res.status(400).json({
                 success: false,
                 message: `Booking rejected. This consultation has reached its maximum capacity of ${maxCapacity} students.`
             });
-        } 
-        
-    
-        else if (maxCapacity - currentBookedStudents === 1) {
-            
+        }
+
+        // Warn if this is the last available spot
+        if (maxCapacity - currentBookedStudents === 1) {
             req.bookingWarning = "You snagged the last spot! This consultation is now full.";
         }
 
-    
+        // Check daily limit for this lecturer
+        const maxDailyConsultations = 10;
+        const currentDailyBookings = await Booking.countDocuments({
+            lecturerId,
+            date,
+            status: { $ne: 'canceled' }
+        });
+        
+        if (currentDailyBookings >= maxDailyConsultations) {
+            return res.status(400).json({
+                success: false,
+                message: `Booking rejected. This lecturer has reached their daily limit of ${maxDailyConsultations} consultations on ${date}.`
+            });
+        }
+        
         next();
 
     } catch (error) {
         console.error("Validation Error:", error);
-        res.status(500).json({ 
-            success: false, 
-            message: "Server error during validation." 
+        res.status(500).json({
+            success: false,
+            message: "Server error during validation."
         });
     }
 };

--- a/src/models/Availability.js
+++ b/src/models/Availability.js
@@ -13,6 +13,7 @@ const dayScheduleSchema = new mongoose.Schema({
 const availabilitySchema = new mongoose.Schema({
   lecturerEmail: { type: String, required: true, unique: true },
   defaultDuration: { type: Number, required: true, default: 30 },
+  dailySessionLimit: { type: Number, required: true, default: 10},
   weeklySchedule: [dayScheduleSchema],
   updatedAt: { type: Date, default: Date.now }
 });

--- a/tests/booking.test.js
+++ b/tests/booking.test.js
@@ -1,16 +1,26 @@
 // tests/booking.test.js
 const request = require('supertest');
-const app = require('../src/app'); 
+const app = require('../src/app');
+const Booking = require('../src/models/booking');
+
+// Mock the Booking model so we can control database responses during tests
+jest.mock('../src/models/booking', () => ({
+  countDocuments: jest.fn()
+}));
 
 describe('Booking Validation Middleware', () => {
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
 
     // Test 1: Missing Data
     it('should reject if required fields are missing', async () => {
         const response = await request(app)
             .post('/api/bookings/create')
             .send({
-                startTime: "10:00" 
-                
+                startTime: "10:00",
+                date: "2026-05-10"
             });
 
         expect(response.status).toBe(400);
@@ -24,6 +34,7 @@ describe('Booking Validation Middleware', () => {
             .post('/api/bookings/create')
             .send({
                 lecturerId: "123",
+                date: "2026-05-10",
                 startTime: "potato",
                 endTime: "11:00"
             });
@@ -39,8 +50,9 @@ describe('Booking Validation Middleware', () => {
             .post('/api/bookings/create')
             .send({
                 lecturerId: "123",
+                date: "2026-05-10",
                 startTime: "14:00",
-                endTime: "10:00" 
+                endTime: "10:00"
             });
 
         expect(response.status).toBe(400);
@@ -48,18 +60,44 @@ describe('Booking Validation Middleware', () => {
         expect(response.body.message).toContain("end time must be after the start time");
     });
 
+    // Test 4: Max Capacity Check
     it('should reject if the consultation is at max capacity', async () => {
+        // Mock: the slot already has 5 students booked (at capacity)
+        Booking.countDocuments.mockResolvedValue(5);
+
         const response = await request(app)
             .post('/api/bookings/create')
             .send({
                 lecturerId: "123",
-                startTime: "10:00", 
-                endTime: "11:00"   
+                date: "2026-05-10",
+                startTime: "10:00",
+                endTime: "11:00"
             });
 
         expect(response.status).toBe(400);
         expect(response.body.success).toBe(false);
         expect(response.body.message).toContain("maximum capacity");
+    });
+
+    // Test 5: Daily Limit Check
+    it('should reject if the lecturer has reached their daily limit', async () => {
+        // Mock: slot has 0 students (under capacity, passes), but lecturer has 10 daily bookings (at daily limit)
+        Booking.countDocuments
+            .mockResolvedValueOnce(0)   // First call: capacity check → 0 < 5, passes
+            .mockResolvedValueOnce(10); // Second call: daily limit check → 10 >= 10, triggers
+
+        const response = await request(app)
+            .post('/api/bookings/create')
+            .send({
+                lecturerId: "123",
+                date: "2026-05-10",
+                startTime: "10:00",
+                endTime: "11:00"
+            });
+
+        expect(response.status).toBe(400);
+        expect(response.body.success).toBe(false);
+        expect(response.body.message).toContain("daily limit");
     });
 
 });


### PR DESCRIPTION
This PR implements robust backend validation for student bookings. It ensures that lecturers are not overbooked by enforcing a maximum daily limit of consultations, verified against the MongoDB database.

 Key Changes

Database-Driven Validation: Replaced hardcoded checks with Booking.countDocuments to accurately track existing consultations in real-time.

Daily Consultation Limit: Implemented a check to ensure no lecturer exceeds 10 consultations per day.

Date Integration: Updated the booking middleware and schema to require a date field, ensuring accurate daily tracking.

Testing Suite: Added comprehensive Jest tests in tests/booking.test.js to cover:

Missing required fields (including the new date requirement).

Validation of daily limits (10/10).

Technical Details

The validateLecturerHours middleware now performs two consecutive database queries:

Checks if the lecturer's total count for that date has reached the daily limit.

Updated the Availability model to include dailySessionLimit with a default of 10.

How to Test

Run npm test to verify the new test cases pass.

Try to create a booking via the API without a date field; it should return a 400 error.

Simulate a full day by adding 10 bookings for a lecturer on one date; the 11th booking should be rejected with the new "daily limit" message.