### PR TITLE
fix: correct registration api paths and logic flow

### DIFF
--- a/public/js/register-page.js
+++ b/public/js/register-page.js
@@ -141,7 +141,7 @@ registrationForm.addEventListener('submit', async (event) => {
 
   // Send to your /register route (using Fetch)
   try {
-    const response = await fetch('/register', {
+    const response = await fetch('api/register', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(formData)


### PR DESCRIPTION
Fixed a bug where the registration form was failing to reach the backend on the live Render deployment.

**API Path Correction:** Updated the fetch request in register-page.js from /register to /api/register to correctly map to the backend route defined in app.js.