### PR TITLE
test/coverall

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,5 @@ jobs:
 
     - name: Upload Coverage to Coveralls
       uses: coverallsapp/github-action@v2
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,13 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x' 
+        node-version: '20.x'
 
     - name: Install Dependencies
       run: npm install
 
-    - name: Run Jest Tests
-      run: npm test
+    - name: Run Coverage
+      run: npm run test:coverage
+
+    - name: Upload Coverage to Coveralls
+      uses: coverallsapp/github-action@v2


### PR DESCRIPTION
## Description

This PR adds code coverage reporting to the CI workflow using Jest and Coveralls.

## What Changed

- Updated the GitHub Actions test workflow to run `npm run test:coverage`
- Generates Jest coverage reports, including `coverage/lcov.info`
- Uploads coverage results to Coveralls using `coverallsapp/github-action@v2`
- Uses the `COVERALLS_REPO_TOKEN` repository secret for Coveralls authentication

## How To Test

Run locally:

```bash
npm run test:coverage
