### PR TITLE
fix: correct path for forgot password link

### DIFF
--- a/public/login-page.html
+++ b/public/login-page.html
@@ -44,7 +44,7 @@
                         <input class="checkbox_button" type="checkbox" id="remember" name="remember">
                         <label class="remember_me" for="remember">Remember me</label>
                     </div>
-                    <a class="forgot_password_text" href="https://www.google.com">Forgot password?</a>
+                    <a class="forgot_password_text" href="forgot-password.html">Forgot password?</a>
                 </div>
             
                 <div>


### PR DESCRIPTION
In this pull request, I have updated our path for forgot password to match our current forgot password page.