### PR TITLE
fix: add input sanitization and session timeout security hardening

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bcrypt": "^6.0.0",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
+    "express-session": "^1.17.4",
     "helmet": "^8.1.0",
     "mongodb": "^7.2.0",
     "mongoose": "^9.5.0"

--- a/src/app.js
+++ b/src/app.js
@@ -1,13 +1,39 @@
 const express = require('express')
+const session = require('express-session')
 const app = express()
 const bcrypt = require('bcrypt')
 const saltRounds = 10
 const path = require('path')
 const User = require('./models/user')
+const { sanitizeRequest } = require('./middleware/input-sanitizer')
 const console = require('console')
+
+const SESSION_IDLE_TIMEOUT = 30 * 60 * 1000 // 30 minutes
 
 // --- Middleware ---
 app.use(express.json())
+app.use(session({
+  secret: process.env.SESSION_SECRET || 'keyboard cat',
+  resave: false,
+  saveUninitialized: false,
+  rolling: true,
+  cookie: {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: SESSION_IDLE_TIMEOUT
+  }
+}))
+app.use(sanitizeRequest)
+app.use((req, res, next) => {
+  if (req.session) {
+    if (req.session.lastActivity && Date.now() - req.session.lastActivity > SESSION_IDLE_TIMEOUT) {
+      req.session.destroy(() => next())
+      return
+    }
+    req.session.lastActivity = Date.now()
+  }
+  next()
+})
 
 // --- Default Route ---
 app.get('/', (req, res) => {
@@ -17,9 +43,6 @@ app.get('/', (req, res) => {
 app.use(express.static(path.join(__dirname, '../public')))
 
 const bookingRoutes = require('./routes/bookings')
-app.use(express.json())
-
-app.use(express.static('public'))
 
 app.use('/api/bookings', bookingRoutes)
 
@@ -91,6 +114,9 @@ app.post('/api/login', async (req, res) => {
       return res.status(401).json({ success: false, message: 'Invalid email or password' })
     }
 
+    req.session.userEmail = email
+    req.session.lastActivity = Date.now()
+
     res.status(200).json({
       success: true,
       message: 'Login successful!',
@@ -103,23 +129,23 @@ app.post('/api/login', async (req, res) => {
 
 // --- Profile Routes ---
 app.get('/api/profile', async (req, res) => {
-  const user = await User.findOne({ email: req.headers['x-user-email'] }).select('name surname email notificationsEnabled');
-  if (!user) return res.status(404).json({ success: false, message: 'User not found.' });
-  res.json({ success: true, user });
-});
+  const email = req.session?.userEmail || req.headers['x-user-email']
+  const user = await User.findOne({ email }).select('name surname email notificationsEnabled')
+  if (!user) return res.status(404).json({ success: false, message: 'User not found.' })
+  res.json({ success: true, user })
+})
 
 app.put('/api/profile', async (req, res) => {
-  const email = req.headers['x-user-email'];
-  const { name, surname, notificationsEnabled } = req.body;
+  const email = req.session?.userEmail || req.headers['x-user-email']
+  const { name, surname, notificationsEnabled } = req.body
   const user = await User.findOneAndUpdate(
     { email },
     { $set: { name, surname, notificationsEnabled } },
     { new: true, select: 'name surname email notificationsEnabled' }
-  );
-  if (!user) return res.status(404).json({ success: false, message: 'User not found.' });
-  res.json({ success: true, message: 'Profile updated.', user });
-});
-
+  )
+  if (!user) return res.status(404).json({ success: false, message: 'User not found.' })
+  res.json({ success: true, message: 'Profile updated.', user })
+})
 
 app.use('/api/activities', require('./routes/activities'));
 

--- a/src/middleware/input-sanitizer.js
+++ b/src/middleware/input-sanitizer.js
@@ -1,0 +1,50 @@
+function escapeString(value) {
+  return value.replace(/[&<>"'`=\/]/g, (char) => {
+    switch (char) {
+      case '&': return '&amp;'
+      case '<': return '&lt;'
+      case '>': return '&gt;'
+      case '"': return '&quot;'
+      case "'": return '&#39;'
+      case '`': return '&#x60;'
+      case '=': return '&#x3D;'
+      case '/': return '&#x2F;'
+      default: return char
+    }
+  })
+}
+
+function sanitizeValue(value) {
+  if (typeof value !== 'string') return value
+  return escapeString(value.trim())
+}
+
+function sanitizeObject(obj) {
+  if (obj === null || obj === undefined) return obj
+  if (typeof obj === 'string') return sanitizeValue(obj)
+  if (typeof obj !== 'object') return obj
+
+  if (Array.isArray(obj)) {
+    return obj.map(sanitizeObject)
+  }
+
+  return Object.entries(obj).reduce((acc, [key, value]) => {
+    const sanitizedKey = key.replace(/^[.$]+/, '').replace(/\./g, '')
+    acc[sanitizedKey] = sanitizeObject(value)
+    return acc
+  }, {})
+}
+
+function sanitizeRequest(req, res, next) {
+  req.body = sanitizeObject(req.body)
+  req.query = sanitizeObject(req.query)
+  req.params = sanitizeObject(req.params)
+
+  if (req.headers['x-user-email']) {
+    req.headers['x-user-email'] = sanitizeValue(req.headers['x-user-email'])
+  }
+
+  next()
+}
+
+module.exports = { sanitizeRequest }

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -18,7 +18,7 @@ const SALT_ROUNDS = 10, TOKEN_EXPIRY_MS = 60 * 60 * 1000
 const hashToken = raw => crypto.createHash('sha256').update(raw).digest('hex')
 
 async function requireAuth(req, res, next) {
-  const email = req.headers['x-user-email']
+  const email = req.session?.userEmail || req.headers['x-user-email']
   if (!email) return res.status(401).json({ success: false, error: 'Unauthorised' })
   const user = await User.findOne({ email })
   if (!user) return res.status(401).json({ success: false, error: 'Unauthorised' })

--- a/tests/unit/input-sanitizer.test.js
+++ b/tests/unit/input-sanitizer.test.js
@@ -1,0 +1,34 @@
+const { sanitizeRequest } = require('../../src/middleware/input-sanitizer')
+
+describe('Input Sanitizer Middleware', () => {
+  it('should escape harmful characters for body, query, params, and headers', () => {
+    const req = {
+      body: {
+        name: '<script>alert(1)</script>',
+        nested: { comment: 'hello & goodbye' },
+        $bad: 'value'
+      },
+      query: {
+        search: 'test<value>'
+      },
+      params: {
+        id: '123<45>'
+      },
+      headers: {
+        'x-user-email': 'john<doe>@wits.ac.za'
+      }
+    }
+    const res = {}
+    const next = jest.fn()
+
+    sanitizeRequest(req, res, next)
+
+    expect(next).toHaveBeenCalled()
+    expect(req.body.name).toBe('&lt;script&gt;alert(1)&lt;&#x2F;script&gt;')
+    expect(req.body.nested.comment).toBe('hello &amp; goodbye')
+    expect(req.body.bad).toBe('value')
+    expect(req.query.search).toBe('test&lt;value&gt;')
+    expect(req.params.id).toBe('123&lt;45&gt;')
+    expect(req.headers['x-user-email']).toBe('john&lt;doe&gt;@wits.ac.za')
+  })
+})


### PR DESCRIPTION
**Summary**
- Added request sanitization middleware to sanitize req.body, req.query, req.params, and x-user-email
- Added session timeout support with express-session (expires after 30 minutes of inactivity)
- Auth now supports session-based authentication with header fallback

**Epic: #1**
**Goal**: Prevent malicious attacks by sanitizing inputs and expiring inactive sessions

**Acceptance Criteria**
Inputs are sanitized against XSS/injection
Sessions expire after 30 minutes of inactivity

**How to Test**
**Unit Tests**
npm install
npm test -- tests/unit/input-sanitizer.test.js

**Manual Session Testing**
1. Start the app
2. Log in via /api/login
3. Verify req.session.userEmail is set
4. Wait 30 minutes or simulate timeout
5. Confirm session is destroyed after inactivity