### PR TITLE
test/loading error

### DIFF
--- a/public/css/lecturer-dashboard.css
+++ b/public/css/lecturer-dashboard.css
@@ -424,8 +424,8 @@ body {
     color: rgba(255, 255, 255, 0.6);
 }
 
-/* Modal */
-.modal {
+/* Session Detail Modal */
+.session-modal-overlay {
     position: fixed;
     top: 0;
     left: 0;
@@ -439,11 +439,15 @@ body {
     backdrop-filter: blur(4px);
 }
 
-.modal.hidden {
+.session-modal-overlay.hidden {
     display: none;
 }
 
-.modal-content {
+body.session-modal-open {
+    overflow: hidden;
+}
+
+.session-modal-panel {
     background-color: rgba(255, 255, 255, 0.95);
     border-radius: 25px;
     width: 90%;
@@ -453,7 +457,7 @@ body {
     box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
 }
 
-.modal-header {
+.session-modal-header {
     padding: 20px 25px;
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);
     display: flex;
@@ -465,7 +469,7 @@ body {
     border-radius: 25px 25px 0 0;
 }
 
-.modal-header h2 {
+.session-modal-header h2 {
     font-size: 20px;
     margin: 0;
     color: #333;

--- a/public/css/lecturer-dashboard.css
+++ b/public/css/lecturer-dashboard.css
@@ -525,14 +525,45 @@ body.session-modal-open {
     padding: 0;
 }
 
+.student-list-heading {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 0 0 6px;
+    color: #333;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.student-list-heading span:last-child {
+    max-width: 45%;
+    text-align: right;
+}
+
 .student-list li {
     padding: 8px 0;
     display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: 10px;
     font-size: 14px;
     color: #555;
     border-bottom: 1px solid rgba(0, 0, 0, 0.04);
+}
+
+.student-list-name {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+.student-list-topic {
+    color: #555;
+    max-width: 45%;
+    text-align: right;
+    overflow-wrap: anywhere;
 }
 
 /* Responsive */

--- a/public/js/booking-page.js
+++ b/public/js/booking-page.js
@@ -32,6 +32,8 @@ document.addEventListener('DOMContentLoaded', () => {
   async function loadFormData () {
     try {
       const response = await fetch('/api/bookings/form-data')
+      if (!response.ok) throw new Error(`Failed to load form data: ${response.status}`)
+
       availabilityData = await response.json()
 
       const uniqueCourses = new Set()

--- a/public/js/lecturer-dashboard.js
+++ b/public/js/lecturer-dashboard.js
@@ -9,14 +9,14 @@ class LecturerScheduleManager {
         this.init();
     }
 
-    init() {
+    async init() {
         this.loadCurrentLecturer();
-        this.loadSessions();
+        await this.loadSessions();
         this.setupEventListeners();
         this.displayCurrentDate();
         this.updateStats();
         this.updateFilterOptions();
-        this.render();
+        this.applyFilters();
     }
 
     // DOM GETTERS
@@ -43,16 +43,31 @@ class LecturerScheduleManager {
         this.dateFilter.addEventListener('change', () => this.handleFilterChange());
         this.searchInput.addEventListener('input', this.debounce(() => this.handleFilterChange(), 300));
 
-        document.getElementById('refresh-btn').addEventListener('click', () => {
-            this.loadSessions();
+        document.getElementById('refresh-btn').addEventListener('click', async () => {
+            await this.loadSessions();
             this.updateStats();
             this.updateFilterOptions();
-            this.render();
+            this.applyFilters();
+        });
+
+        this.scheduleList.addEventListener('click', (e) => {
+            const button = e.target.closest('[data-session-action]');
+            if (!button) return;
+
+            const sessionId = button.dataset.sessionId;
+            if (button.dataset.sessionAction === 'details') this.showDetail(sessionId);
+            if (button.dataset.sessionAction === 'cancel') this.cancelSession(sessionId);
+            if (button.dataset.sessionAction === 'complete') this.completeSession(sessionId);
         });
 
         document.getElementById('close-session-modal').addEventListener('click', () => this.closeModal());
         this.sessionModal.addEventListener('click', (e) => {
             if (e.target === this.sessionModal) this.closeModal();
+        });
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && !this.sessionModal.classList.contains('hidden')) {
+                this.closeModal();
+            }
         });
     }
 
@@ -78,26 +93,85 @@ class LecturerScheduleManager {
         this.currentLecturer = null;
     }
  ///Running sessions from the databse
+    getCurrentLecturerId() {
+        return this.currentLecturer?.idNumber || this.currentLecturer?.email || '';
+    }
+
     async loadSessions() {
-    const email = this.currentLecturer?.email || '';
-    const response = await fetch(`/api/bookings/lecturer/bookings?email=${encodeURIComponent(email)}`);
+    const lecturerId = this.getCurrentLecturerId();
+    if (!lecturerId) {
+        this.sessions = [];
+        this.filteredSessions = [];
+        return;
+    }
+
+    const response = await fetch(`/api/bookings/lecturer/bookings?email=${encodeURIComponent(lecturerId)}`);
 
     if (response.ok) {
         const bookings = await response.json();
-        this.sessions = bookings.map(b => ({
+        this.sessions = this.groupBookingsBySession(bookings).map(b => ({
             id: b._id,
+            bookingIds: b.bookingIds || [b._id],
             courseCode: b.module || '',
-            studentName: b.studentId || 'Unknown',
+            studentName: b.joinedStudents.length === 1 ? b.joinedStudents[0] : `${b.joinedStudents.length} students`,
             date: b.date ? b.date.split('T')[0] : '',
             time: b.startTime || '',
             duration: this.calculateDuration(b.startTime, b.endTime),
             status: b.status || 'upcoming',
             topic: b.topic || '',
-            joinedStudents: b.participantIDs || [],
+            joinedStudents: b.joinedStudents,
             
     }));
     }
 }
+    groupBookingsBySession(bookings) {
+        const grouped = new Map();
+
+        bookings.forEach(booking => {
+            const date = booking.date ? booking.date.split('T')[0] : '';
+            const key = [
+                booking.module || '',
+                date,
+                booking.startTime || '',
+                booking.endTime || '',
+                booking.status || 'upcoming'
+            ].join('|');
+
+            if (!grouped.has(key)) {
+                grouped.set(key, {
+                    ...booking,
+                    date,
+                    bookingIds: [],
+                    joinedStudents: [],
+                    firstBookingAt: booking.createdAt || ''
+                });
+            }
+
+            const session = grouped.get(key);
+            session.bookingIds.push(booking._id);
+
+            const sessionTime = session.firstBookingAt ? new Date(session.firstBookingAt).getTime() : Number.MAX_SAFE_INTEGER;
+            const bookingTime = booking.createdAt ? new Date(booking.createdAt).getTime() : Number.MAX_SAFE_INTEGER;
+            if (booking.topic && (!session.topic || bookingTime < sessionTime)) {
+                session.topic = booking.topic;
+                session.firstBookingAt = booking.createdAt || session.firstBookingAt;
+            }
+
+            const students = [
+                booking.studentId,
+                ...(Array.isArray(booking.participantIDs) ? booking.participantIDs : [])
+            ].filter(Boolean);
+
+            students.forEach(student => {
+                if (!session.joinedStudents.includes(student)) {
+                    session.joinedStudents.push(student);
+                }
+            });
+
+        });
+
+        return Array.from(grouped.values());
+    }
     async updateSessionStatus(session) {
     await fetch(`/api/bookings/${session._id || session.id}`, {
         method: 'PUT',
@@ -130,7 +204,7 @@ class LecturerScheduleManager {
             }
 
             if (searchTerm) {
-                const searchStr = `${session.studentName || ''} ${session.courseCode || ''} ${session.topic || ''}`.toLowerCase();
+                const searchStr = `${session.studentName || ''} ${session.courseCode || ''} ${session.topic || ''} ${(session.joinedStudents || []).join(' ')}`.toLowerCase();
                 if (!searchStr.includes(searchTerm)) return false;
             }
 
@@ -216,16 +290,16 @@ class LecturerScheduleManager {
                 </div>
                 <span class="session-status ${statusClass}">${session.status || 'unknown'}</span>
                 <div class="session-actions">
-                    <button class="btn btn-sm btn-outline" onclick="scheduleManager.showDetail('${session.id}')">
+                    <button class="btn btn-sm btn-outline" data-session-action="details" data-session-id="${this.escape(session.id)}">
                         <i class="fas fa-info-circle"></i> Details
                     </button>
                     ${session.status === 'upcoming' ? `
-                        <button class="btn btn-sm btn-danger" onclick="scheduleManager.cancelSession('${session.id}')">
+                        <button class="btn btn-sm btn-danger" data-session-action="cancel" data-session-id="${this.escape(session.id)}">
                             <i class="fas fa-times"></i> Cancel
                         </button>
                     ` : ''}
                     ${session.status === 'ongoing' ? `
-                        <button class="btn btn-sm btn-success" onclick="scheduleManager.completeSession('${session.id}')">
+                        <button class="btn btn-sm btn-success" data-session-action="complete" data-session-id="${this.escape(session.id)}">
                             <i class="fas fa-check"></i> Complete
                         </button>
                     ` : ''}
@@ -280,19 +354,39 @@ class LecturerScheduleManager {
             </div>
         `;
 
+        this.openModal();
+    }
+
+    openModal() {
         this.sessionModal.classList.remove('hidden');
+        this.sessionModal.setAttribute('aria-hidden', 'false');
+        document.body.classList.add('session-modal-open');
     }
 
     closeModal() {
         this.sessionModal.classList.add('hidden');
+        this.sessionModal.setAttribute('aria-hidden', 'true');
+        document.body.classList.remove('session-modal-open');
     }
 
-    cancelSession(id) {
+    async cancelSession(id) {
         if (confirm('Cancel this session?')) {
             const session = this.sessions.find(s => s.id === id);
             if (session) {
+                const bookingIds = session.bookingIds && session.bookingIds.length > 0 ? session.bookingIds : [session.id];
+                const response = await fetch('/api/bookings/session/cancel', {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ bookingIds })
+                });
+
+                if (!response.ok) {
+                    alert('Failed to cancel session. Please try again.');
+                    return;
+                }
+
                 session.status = 'canceled';
-                this.saveSessions();
+                this.closeModal();
                 this.updateStats();
                 this.applyFilters();
             }
@@ -377,11 +471,13 @@ class LecturerScheduleManager {
 const settingsBtn = document.getElementById('settings-btn');
 const settingsDropdown = document.getElementById('settings-dropdown');
 
-document.addEventListener('click', function(e) {
-    if (!settingsBtn.contains(e.target) && !settingsDropdown.contains(e.target)) {
-        settingsDropdown.classList.add('hidden');
-    }
-});
+if (settingsBtn && settingsDropdown) {
+    document.addEventListener('click', function(e) {
+        if (!settingsBtn.contains(e.target) && !settingsDropdown.contains(e.target)) {
+            settingsDropdown.classList.add('hidden');
+        }
+    });
+}
 
 
 // INITIALIZE

--- a/public/js/lecturer-dashboard.js
+++ b/public/js/lecturer-dashboard.js
@@ -120,6 +120,7 @@ class LecturerScheduleManager {
             status: b.status || 'upcoming',
             topic: b.topic || '',
             joinedStudents: b.joinedStudents,
+            studentTopics: b.studentTopics || {},
             
     }));
     }
@@ -143,6 +144,7 @@ class LecturerScheduleManager {
                     date,
                     bookingIds: [],
                     joinedStudents: [],
+                    studentTopics: {},
                     firstBookingAt: booking.createdAt || ''
                 });
             }
@@ -165,6 +167,9 @@ class LecturerScheduleManager {
             students.forEach(student => {
                 if (!session.joinedStudents.includes(student)) {
                     session.joinedStudents.push(student);
+                }
+                if (!session.studentTopics[student]) {
+                    session.studentTopics[student] = booking.topic || 'No topic specified';
                 }
             });
 
@@ -264,6 +269,7 @@ class LecturerScheduleManager {
         const timeDisplay = this.formatTime(session.time);
         const statusClass = `status-${session.status}`;
         const joinedStudents = session.joinedStudents || [];
+        const studentTopics = session.studentTopics || {};
         const location = session.location || 'Not specified';
 
         return `
@@ -317,6 +323,7 @@ class LecturerScheduleManager {
         });
 
         const joinedStudents = session.joinedStudents || [];
+        const studentTopics = session.studentTopics || {};
         const location = session.location || 'Not specified';
 
         this.sessionDetailContent.innerHTML = `
@@ -347,8 +354,17 @@ class LecturerScheduleManager {
             <div class="detail-students">
                 <h4>Students Joined (${joinedStudents.length})</h4>
                 ${joinedStudents.length > 0 ? `
+                    <div class="student-list-heading">
+                        <span>Student</span>
+                        <span>Topic</span>
+                    </div>
                     <ul class="student-list">
-                        ${joinedStudents.map(s => `<li><i class="fas fa-user-circle"></i> ${this.escape(s)}</li>`).join('')}
+                        ${joinedStudents.map(s => `
+                            <li>
+                                <span class="student-list-name"><i class="fas fa-user-circle"></i> ${this.escape(s)}</span>
+                                <span class="student-list-topic">${this.escape(studentTopics[s] || 'No topic specified')}</span>
+                            </li>
+                        `).join('')}
                     </ul>
                 ` : '<p style="color: #888; font-size: 13px;">No students have joined yet.</p>'}
             </div>

--- a/public/js/student-dashboard.js
+++ b/public/js/student-dashboard.js
@@ -195,6 +195,13 @@ class StudentScheduleManager {
   renderSessionCard (session) {
     const timeDisplay = this.formatTime(session.time)
     const location = session.location || 'Online'
+    const statusConfig = {
+      upcoming: { border: 'border-warning', badge: 'bg-warning text-dark' },
+      ongoing: { border: 'border-info', badge: 'bg-info text-dark' },
+      completed: { border: 'border-success', badge: 'bg-success' },
+      canceled: { border: 'border-danger', badge: 'bg-danger' }
+    }
+    const config = statusConfig[session.status] || { border: 'border-secondary', badge: 'bg-secondary' }
 
     const isOrganizer = this.currentStudent && this.currentStudent.email === session.organizerEmail
 
@@ -286,8 +293,14 @@ class StudentScheduleManager {
         `
 : ''}
     `
+    document.getElementById('session-modal').classList.remove('hidden')
     // Use the Bootstrap instance to show the modal
     this.bsModal.show()
+  }
+
+  closeModal () {
+    document.getElementById('session-modal').classList.add('hidden')
+    this.bsModal.hide()
   }
 
   async cancelBooking (sessionId) {

--- a/public/lecturer-dashboard.html
+++ b/public/lecturer-dashboard.html
@@ -131,9 +131,9 @@
     </div>
 
     <!-- Session Detail Modal -->
-    <div id="session-modal" class="modal hidden">
-        <div class="modal-content">
-            <div class="modal-header">
+    <div id="session-modal" class="session-modal-overlay hidden" aria-hidden="true">
+        <div class="session-modal-panel">
+            <div class="session-modal-header">
                 <h2>Session Details</h2>
                 <button class="close-btn" id="close-session-modal">&times;</button>
             </div>

--- a/src/models/booking.js
+++ b/src/models/booking.js
@@ -28,6 +28,11 @@ const bookingSchema = new mongoose.Schema({
     required: true,
     trim: true
   },
+  topic: {
+    type: String,
+    default: '',
+    trim: true
+  },
   createdAt: {
     type: Date,
     default: Date.now

--- a/src/routes/bookings.js
+++ b/src/routes/bookings.js
@@ -57,6 +57,10 @@ router.get('/availability', async (req, res) => {
 
 async function createBooking(req, res) {
   try {
+    if (!req.body.topic || !req.body.topic.trim()) {
+      return res.status(400).json({ success: false, message: 'Topic is required' })
+    }
+
     const newBooking = new Booking({
       studentId: req.body.studentId,
       lecturerId: req.body.lecturerId,
@@ -64,7 +68,7 @@ async function createBooking(req, res) {
       startTime: req.body.startTime,
       endTime: req.body.endTime,
       module: req.body.module,
-      topic: req.body.topic,
+      topic: req.body.topic.trim(),
       status: 'upcoming',
       participantIDs: [req.body.studentId], // CRITICAL for your "leave" feature
       leftParticipantIDs: []

--- a/src/routes/bookings.js
+++ b/src/routes/bookings.js
@@ -25,7 +25,7 @@ router.get('/availability', async (req, res) => {
     const dateObj = new Date(date)
     const dayOfWeek = dateObj.getDay()
 
-    const schedule = await Availability.findOne({ lecturerId })
+    const schedule = await Availability.findOne({ lecturerEmail: lecturerId })
 
     if (!schedule) {
       return res.status(404).json({ error: 'Lecturer availability not found.' })
@@ -55,9 +55,7 @@ router.get('/availability', async (req, res) => {
   }
 })
 
-// POST: Save a new booking (MERGED AND FIXED!)
-// Notice how it uses your middleware AND saves the data properly now
-router.post('/', validateLecturerHours, async (req, res) => {
+async function createBooking(req, res) {
   try {
     const newBooking = new Booking({
       studentId: req.body.studentId,
@@ -78,7 +76,12 @@ router.post('/', validateLecturerHours, async (req, res) => {
     console.error(error)
     res.status(500).json({ error: 'Failed to create booking' })
   }
-})
+}
+
+// POST: Save a new booking (MERGED AND FIXED!)
+// Notice how it uses your middleware AND saves the data properly now
+router.post('/', validateLecturerHours, createBooking)
+router.post('/create', validateLecturerHours, createBooking)
 
 // GET: Fetch ONLY the logged-in student's bookings (RESTORED GROUP LOGIC)
 router.get('/', async (req, res) => {

--- a/src/routes/bookings.js
+++ b/src/routes/bookings.js
@@ -83,6 +83,31 @@ async function createBooking(req, res) {
 router.post('/', validateLecturerHours, createBooking)
 router.post('/create', validateLecturerHours, createBooking)
 
+// PUT: Cancel every booking that belongs to the same grouped lecturer session
+router.put('/session/cancel', async (req, res) => {
+  try {
+    const { bookingIds } = req.body
+
+    if (!Array.isArray(bookingIds) || bookingIds.length === 0) {
+      return res.status(400).json({ success: false, message: 'bookingIds are required' })
+    }
+
+    const result = await Booking.updateMany(
+      { _id: { $in: bookingIds } },
+      { $set: { status: 'canceled' } }
+    )
+
+    res.json({
+      success: true,
+      message: 'Session canceled for all participants',
+      modifiedCount: result.modifiedCount || 0
+    })
+  } catch (error) {
+    console.error(error)
+    res.status(500).json({ success: false, message: 'Failed to cancel session' })
+  }
+})
+
 // GET: Fetch ONLY the logged-in student's bookings (RESTORED GROUP LOGIC)
 router.get('/', async (req, res) => {
   try {
@@ -194,8 +219,7 @@ router.get('/lecturer/bookings', async (req, res) => {
   try {
     const { email } = req.query
     const bookings = await Booking.find({
-      lecturerId: email,
-      status: 'upcoming'
+      lecturerId: email
     }).sort({ date: 1, startTime: 1 })
 
     res.json(bookings)

--- a/tests/acceptance/user-flows.test.js
+++ b/tests/acceptance/user-flows.test.js
@@ -6,12 +6,14 @@ const app = require('../../src/app');
 const User = require('../../src/models/user');
 const Booking = require('../../src/models/booking');
 const Schedule = require('../../src/models/Schedule');
+const Availability = require('../../src/models/Availability');
 const PasswordResetToken = require('../../src/models/passwordResetToken');
 const { sendPasswordResetEmail, sendNotification } = require('../../src/utils/emailService');
 
 jest.mock('../../src/models/user');
 jest.mock('../../src/models/booking');
 jest.mock('../../src/models/Schedule');
+jest.mock('../../src/models/Availability');
 jest.mock('../../src/models/passwordResetToken');
 jest.mock('../../src/utils/emailService', () => ({
   sendPasswordResetEmail: jest.fn(),
@@ -189,15 +191,14 @@ describe('User Acceptance Flows', () => {
   });
 
   it('allows a student to see available consultation blocks before booking', async () => {
-    const schedule = {
-      lecturerId: 'lecturer@wits.ac.za',
-      defaultDuration: 30,
+    const availability = {
+      lecturerEmail: 'lecturer@wits.ac.za',
       weeklySchedule: [
-        { dayOfWeek: 2, slots: [{ start: '10:00', end: '11:00' }] }
+        { dayOfWeek: 2, slots: [{ start: '10:00', end: '11:00', duration: 30 }] }
       ]
     };
 
-    Schedule.findOne.mockResolvedValue(schedule);
+    Availability.findOne.mockResolvedValue(availability);
     Booking.find.mockResolvedValue([
       { startTime: '10:00', status: 'upcoming' }
     ]);
@@ -205,17 +206,16 @@ describe('User Acceptance Flows', () => {
     const response = await request(app)
       .get('/api/bookings/availability')
       .query({
-        lecturerId: schedule.lecturerId,
+        lecturerId: availability.lecturerEmail,
         date: '2026-05-05'
       });
 
     expect(response.status).toBe(200);
-    expect(response.body.duration).toBe(schedule.defaultDuration);
-    expect(response.body.availableBlocks).toEqual(schedule.weeklySchedule[0].slots);
+    expect(response.body.availableBlocks).toEqual(availability.weeklySchedule[0].slots);
     expect(response.body.bookedTimes).toEqual(['10:00']);
-    expect(Schedule.findOne).toHaveBeenCalledWith({ lecturerId: schedule.lecturerId });
+    expect(Availability.findOne).toHaveBeenCalledWith({ lecturerEmail: availability.lecturerEmail });
     expect(Booking.find).toHaveBeenCalledWith({
-      lecturerId: schedule.lecturerId,
+      lecturerId: availability.lecturerEmail,
       date: '2026-05-05',
       status: { $ne: 'canceled' }
     });

--- a/tests/acceptance/user-flows.test.js
+++ b/tests/acceptance/user-flows.test.js
@@ -51,6 +51,7 @@ describe('User Acceptance Flows', () => {
       startTime: '09:30',
       endTime: '10:00',
       module: 'PHYS1000',
+      topic: 'First student topic',
       status: 'upcoming'
     };
     const lean = jest.fn().mockResolvedValue([booking]);
@@ -99,7 +100,8 @@ describe('User Acceptance Flows', () => {
         startTime: booking.startTime,
         endTime: booking.endTime,
         module: booking.module,
-        studentId: student.email
+        studentId: student.email,
+        topic: booking.topic
       });
 
     expect(bookResponse.status).toBe(201);

--- a/tests/integration/booking-integration.test.js
+++ b/tests/integration/booking-integration.test.js
@@ -16,13 +16,13 @@ jest.mock('../../src/models/booking', () => {
   return Booking;
 });
 
-jest.mock('../../src/models/Schedule', () => ({
+jest.mock('../../src/models/Availability', () => ({
   findOne: jest.fn()
 }));
 
 const app = require('../../src/app');
 const Booking = require('../../src/models/booking');
-const Schedule = require('../../src/models/Schedule');
+const Availability = require('../../src/models/Availability');
 
 describe('Booking Integration Tests', () => {
   beforeEach(() => {
@@ -84,11 +84,10 @@ describe('Booking Integration Tests', () => {
   });
 
   it('returns available blocks and booked times for a lecturer and date', async () => {
-    Schedule.findOne.mockResolvedValue({
-      lecturerId: 'lecturer@wits.ac.za',
-      defaultDuration: 30,
+    Availability.findOne.mockResolvedValue({
+      lecturerEmail: 'lecturer@wits.ac.za',
       weeklySchedule: [
-        { dayOfWeek: 1, slots: [{ start: '09:00', end: '10:00' }] }
+        { dayOfWeek: 1, slots: [{ start: '09:00', end: '10:00', duration: 30 }] }
       ]
     });
     Booking.find.mockResolvedValue([
@@ -104,11 +103,10 @@ describe('Booking Integration Tests', () => {
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
-      duration: 30,
-      availableBlocks: [{ start: '09:00', end: '10:00' }],
+      availableBlocks: [{ start: '09:00', end: '10:00', duration: 30 }],
       bookedTimes: ['09:00']
     });
-    expect(Schedule.findOne).toHaveBeenCalledWith({ lecturerId: 'lecturer@wits.ac.za' });
+    expect(Availability.findOne).toHaveBeenCalledWith({ lecturerEmail: 'lecturer@wits.ac.za' });
     expect(Booking.find).toHaveBeenCalledWith({
       lecturerId: 'lecturer@wits.ac.za',
       date: '2026-06-01',
@@ -117,9 +115,8 @@ describe('Booking Integration Tests', () => {
   });
 
   it('returns an empty availability response when the lecturer has no slots that day', async () => {
-    Schedule.findOne.mockResolvedValue({
-      lecturerId: 'lecturer@wits.ac.za',
-      defaultDuration: 30,
+    Availability.findOne.mockResolvedValue({
+      lecturerEmail: 'lecturer@wits.ac.za',
       weeklySchedule: [
         { dayOfWeek: 2, slots: [{ start: '09:00', end: '10:00' }] }
       ]
@@ -135,14 +132,14 @@ describe('Booking Integration Tests', () => {
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
       message: 'Lecturer is not available on this day.',
-      slots: [],
-      booked: []
+      availableBlocks: [],
+      bookedTimes: []
     });
     expect(Booking.find).not.toHaveBeenCalled();
   });
 
   it('returns 404 when lecturer availability does not exist', async () => {
-    Schedule.findOne.mockResolvedValue(null);
+    Availability.findOne.mockResolvedValue(null);
 
     const response = await request(app)
       .get('/api/bookings/availability')

--- a/tests/integration/booking-integration.test.js
+++ b/tests/integration/booking-integration.test.js
@@ -11,6 +11,7 @@ jest.mock('../../src/models/booking', () => {
   Booking.find = jest.fn();
   Booking.findById = jest.fn();
   Booking.findByIdAndUpdate = jest.fn();
+  Booking.updateMany = jest.fn();
   Booking.prototype.save = save;
 
   return Booking;
@@ -220,5 +221,23 @@ describe('Booking Integration Tests', () => {
     expect(response.status).toBe(403);
     expect(response.body.message).toContain('Unauthorized');
     expect(Booking.findByIdAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('cancels every booking in a grouped lecturer session', async () => {
+    Booking.updateMany.mockResolvedValue({ modifiedCount: 2 });
+
+    const response = await request(app)
+      .put('/api/bookings/session/cancel')
+      .send({ bookingIds: ['booking-1', 'booking-2'] });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      success: true,
+      modifiedCount: 2
+    });
+    expect(Booking.updateMany).toHaveBeenCalledWith(
+      { _id: { $in: ['booking-1', 'booking-2'] } },
+      { $set: { status: 'canceled' } }
+    );
   });
 });

--- a/tests/integration/booking-integration.test.js
+++ b/tests/integration/booking-integration.test.js
@@ -37,7 +37,8 @@ describe('Booking Integration Tests', () => {
       startTime: '10:00',
       endTime: '11:00',
       module: 'ELEN4010',
-      studentId: 'student@wits.ac.za'
+      studentId: 'student@wits.ac.za',
+      topic: 'First student topic'
     };
     const savedBooking = { _id: 'mock_id', ...bookingRequest, status: 'upcoming' };
 
@@ -67,6 +68,25 @@ describe('Booking Integration Tests', () => {
       status: 'upcoming'
     }));
     expect(Booking.prototype.save).toHaveBeenCalled();
+  });
+
+  it('requires a topic when creating a booking', async () => {
+    Booking.countDocuments.mockResolvedValue(0);
+
+    const response = await request(app)
+      .post('/api/bookings/create')
+      .send({
+        lecturerId: 'lecturer@wits.ac.za',
+        date: '2026-06-01',
+        startTime: '10:00',
+        endTime: '11:00',
+        module: 'ELEN4010',
+        studentId: 'student@wits.ac.za'
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe('Topic is required');
+    expect(Booking.prototype.save).not.toHaveBeenCalled();
   });
 
   it('rejects invalid booking requests before saving', async () => {

--- a/tests/unit/frontend-pages.test.js
+++ b/tests/unit/frontend-pages.test.js
@@ -218,26 +218,46 @@ describe('Booking page browser script', () => {
     sessionStorage.setItem('sychro_current_user', JSON.stringify({
       email: 'student@wits.ac.za'
     }));
-    fetch
-      .mockResolvedValueOnce({
+    fetch.mockImplementation((url) => {
+      if (url === '/api/bookings/form-data') {
+        return Promise.resolve({
+        ok: true,
+        json: jest.fn().mockResolvedValue([
+          {
+            lecturerEmail: 'lecturer_1',
+            courses: ['ELEN4010'],
+            weeklySchedule: []
+          }
+        ])
+      })
+      }
+
+      if (url.startsWith('/api/bookings/availability')) {
+        return Promise.resolve({
+        ok: true,
         json: jest.fn().mockResolvedValue({
-          duration: 30,
-          availableBlocks: [{ start: '09:00', end: '10:00' }],
-          bookedTimes: ['09:00']
+          availableBlocks: [{ start: '09:30', end: '10:00', course: 'ELEN4010', maxStudents: 5 }],
+          bookedTimes: []
         })
       })
-      .mockResolvedValueOnce({ ok: true });
+      }
+
+      return Promise.resolve({ ok: true });
+    });
     loadFreshScript('booking-page.js');
 
     document.dispatchEvent(new Event('DOMContentLoaded'));
+    await flushPromises();
     document.getElementById('module').value = 'ELEN4010';
+    document.getElementById('module').dispatchEvent(new Event('change'));
     document.getElementById('lecturerId').value = 'lecturer_1';
     document.getElementById('bookingDate').value = '2026-06-01';
     document.getElementById('bookingDate').dispatchEvent(new Event('change'));
     await flushPromises();
+    await flushPromises();
 
     const slotButton = document.querySelector('.slot-btn');
-    expect(slotButton.innerText).toBe('09:30 - 10:00');
+    expect(slotButton.textContent.trim()).toBe('09:30 - 10:00');
 
     slotButton.click();
     expect(document.getElementById('selectedStartTime').value).toBe('09:30');
@@ -250,7 +270,7 @@ describe('Booking page browser script', () => {
     }));
     await flushPromises();
 
-    expect(fetch).toHaveBeenNthCalledWith(2, '/api/bookings', expect.objectContaining({
+    expect(fetch).toHaveBeenCalledWith('/api/bookings', expect.objectContaining({
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/tests/unit/lecturer-dashboard.test.js
+++ b/tests/unit/lecturer-dashboard.test.js
@@ -47,7 +47,7 @@ beforeEach(() => {
         <input id="search-input" type="text" />
         <div id="schedule-list"></div>
         <div id="empty-state" class="hidden"></div>
-        <div id="session-modal" class="modal hidden">
+        <div id="session-modal" class="session-modal-overlay hidden" aria-hidden="true">
             <div id="session-detail-content"></div>
         </div>
         <button id="refresh-btn"></button>
@@ -146,6 +146,163 @@ describe('Lecturer Dashboard', () => {
             expect(manager.sessions).toEqual([]);
         });
 
+        test('should show bookings made against lecturer idNumber on the dashboard', async () => {
+            global.sessionStorage.setItem('sychro_current_user', JSON.stringify({
+                fullName: 'Dr. Stephen',
+                email: 'stephen@wits.ac.za',
+                idNumber: '2540701'
+            }));
+            global.fetch.mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve([
+                    {
+                        _id: 'booking-1',
+                        lecturerId: '2540701',
+                        studentId: 'student@wits.ac.za',
+                        module: 'ELEN4010',
+                        date: '2026-05-18',
+                        startTime: '08:00',
+                        endTime: '09:00',
+                        status: 'upcoming',
+                        topic: 'Arrays',
+                        participantIDs: ['student@wits.ac.za']
+                    }
+                ])
+            });
+
+            const manager = new LecturerScheduleManager();
+            await waitForInit();
+
+            expect(fetch).toHaveBeenCalledWith('/api/bookings/lecturer/bookings?email=2540701');
+            expect(manager.sessions).toHaveLength(1);
+            expect(document.getElementById('schedule-list').textContent).toContain('ELEN4010');
+            expect(document.getElementById('schedule-list').textContent).toContain('Arrays');
+            expect(document.getElementById('empty-state').classList.contains('hidden')).toBe(true);
+        });
+
+        test('should group multiple student bookings for the same consultation slot', async () => {
+            global.sessionStorage.setItem('sychro_current_user', JSON.stringify({
+                fullName: 'Dr. Stephen',
+                email: 'stephen@wits.ac.za',
+                idNumber: '2540701'
+            }));
+            global.fetch.mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve([
+                    {
+                        _id: 'booking-1',
+                        lecturerId: '2540701',
+                        studentId: 'alice@wits.ac.za',
+                        module: 'ELEN4010',
+                        date: '2026-05-18',
+                        startTime: '08:00',
+                        endTime: '09:00',
+                        status: 'upcoming',
+                        topic: 'First student topic',
+                        createdAt: '2026-05-01T08:00:00.000Z',
+                        participantIDs: ['alice@wits.ac.za']
+                    },
+                    {
+                        _id: 'booking-2',
+                        lecturerId: '2540701',
+                        studentId: 'bob@wits.ac.za',
+                        module: 'ELEN4010',
+                        date: '2026-05-18',
+                        startTime: '08:00',
+                        endTime: '09:00',
+                        status: 'upcoming',
+                        topic: 'Second student topic',
+                        createdAt: '2026-05-01T08:05:00.000Z',
+                        participantIDs: ['bob@wits.ac.za']
+                    }
+                ])
+            });
+
+            const manager = new LecturerScheduleManager();
+            await waitForInit();
+
+            expect(manager.sessions).toHaveLength(1);
+            expect(manager.sessions[0].joinedStudents).toEqual(['alice@wits.ac.za', 'bob@wits.ac.za']);
+            expect(manager.sessions[0].topic).toBe('First student topic');
+            expect(document.querySelectorAll('.session-card')).toHaveLength(1);
+            expect(document.getElementById('schedule-list').textContent).toContain('2 joined');
+            expect(document.getElementById('schedule-list').textContent).toContain('First student topic');
+            expect(document.getElementById('schedule-list').textContent).not.toContain('Second student topic');
+
+            document.querySelector('[data-session-action="details"]').click();
+
+            expect(document.getElementById('session-detail-content').textContent).toContain('Students Joined (2)');
+            expect(document.getElementById('session-detail-content').textContent).toContain('First student topic');
+            expect(document.getElementById('session-detail-content').textContent).not.toContain('Second student topic');
+            expect(document.getElementById('session-detail-content').textContent).toContain('alice@wits.ac.za');
+            expect(document.getElementById('session-detail-content').textContent).toContain('bob@wits.ac.za');
+            expect(document.getElementById('session-modal').classList.contains('hidden')).toBe(false);
+            expect(document.getElementById('session-modal').getAttribute('aria-hidden')).toBe('false');
+
+            document.getElementById('close-session-modal').click();
+
+            expect(document.getElementById('session-modal').classList.contains('hidden')).toBe(true);
+            expect(document.getElementById('session-modal').getAttribute('aria-hidden')).toBe('true');
+        });
+
+        test('should cancel every booking in a grouped lecturer session', async () => {
+            global.confirm = jest.fn(() => true);
+            global.alert = jest.fn();
+            global.sessionStorage.setItem('sychro_current_user', JSON.stringify({
+                fullName: 'Dr. Stephen',
+                email: 'stephen@wits.ac.za',
+                idNumber: '2540701'
+            }));
+            global.fetch
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: () => Promise.resolve([
+                        {
+                            _id: 'booking-1',
+                            lecturerId: '2540701',
+                            studentId: 'alice@wits.ac.za',
+                            module: 'ELEN4010',
+                            date: '2026-05-18',
+                            startTime: '08:00',
+                            endTime: '09:00',
+                            status: 'upcoming',
+                            topic: 'Arrays',
+                            participantIDs: ['alice@wits.ac.za']
+                        },
+                        {
+                            _id: 'booking-2',
+                            lecturerId: '2540701',
+                            studentId: 'bob@wits.ac.za',
+                            module: 'ELEN4010',
+                            date: '2026-05-18',
+                            startTime: '08:00',
+                            endTime: '09:00',
+                            status: 'upcoming',
+                            topic: 'Arrays',
+                            participantIDs: ['bob@wits.ac.za']
+                        }
+                    ])
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: () => Promise.resolve({ success: true, modifiedCount: 2 })
+                });
+
+            const manager = new LecturerScheduleManager();
+            await waitForInit();
+
+            await manager.cancelSession('booking-1');
+
+            expect(fetch).toHaveBeenCalledWith('/api/bookings/session/cancel', expect.objectContaining({
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ bookingIds: ['booking-1', 'booking-2'] })
+            }));
+            expect(manager.sessions[0].status).toBe('canceled');
+            expect(document.getElementById('schedule-list').textContent).toContain('canceled');
+            expect(global.alert).not.toHaveBeenCalled();
+        });
+
     });
 
     describe('Statistics Calculation', () => {
@@ -170,8 +327,9 @@ describe('Lecturer Dashboard', () => {
             expect(document.getElementById('schedule-list').innerHTML).toBe('');
         });
 
-        test('should display current date', () => {
+        test('should display current date', async () => {
             const manager = new LecturerScheduleManager();
+            await waitForInit();
             const dateEl = document.getElementById('current-date');
             expect(dateEl.textContent).not.toBe('');
         });

--- a/tests/unit/lecturer-dashboard.test.js
+++ b/tests/unit/lecturer-dashboard.test.js
@@ -224,6 +224,10 @@ describe('Lecturer Dashboard', () => {
             expect(manager.sessions).toHaveLength(1);
             expect(manager.sessions[0].joinedStudents).toEqual(['alice@wits.ac.za', 'bob@wits.ac.za']);
             expect(manager.sessions[0].topic).toBe('First student topic');
+            expect(manager.sessions[0].studentTopics).toEqual({
+                'alice@wits.ac.za': 'First student topic',
+                'bob@wits.ac.za': 'Second student topic'
+            });
             expect(document.querySelectorAll('.session-card')).toHaveLength(1);
             expect(document.getElementById('schedule-list').textContent).toContain('2 joined');
             expect(document.getElementById('schedule-list').textContent).toContain('First student topic');
@@ -232,8 +236,9 @@ describe('Lecturer Dashboard', () => {
             document.querySelector('[data-session-action="details"]').click();
 
             expect(document.getElementById('session-detail-content').textContent).toContain('Students Joined (2)');
+            expect(document.querySelector('.student-list-heading').textContent).toContain('Topic');
             expect(document.getElementById('session-detail-content').textContent).toContain('First student topic');
-            expect(document.getElementById('session-detail-content').textContent).not.toContain('Second student topic');
+            expect(document.getElementById('session-detail-content').textContent).toContain('Second student topic');
             expect(document.getElementById('session-detail-content').textContent).toContain('alice@wits.ac.za');
             expect(document.getElementById('session-detail-content').textContent).toContain('bob@wits.ac.za');
             expect(document.getElementById('session-modal').classList.contains('hidden')).toBe(false);

--- a/tests/unit/student-dashboard.test.js
+++ b/tests/unit/student-dashboard.test.js
@@ -15,6 +15,12 @@ global.fetch = jest.fn(() =>
 
 global.confirm = jest.fn(() => true)
 global.alert = jest.fn()
+global.bootstrap = {
+  Modal: jest.fn().mockImplementation(() => ({
+    show: jest.fn(),
+    hide: jest.fn()
+  }))
+}
 
 const { StudentScheduleManager } = require('../../public/js/student-dashboard.js')
 


### PR DESCRIPTION
## Summary

- Fixed lecturer dashboard session grouping so multiple students booked into the same consultation slot appear under one session card.
- Updated lecturer session details to list all joined students and show each student’s topic in a right-aligned `Topic` column.
- Added a topic heading row in the session details modal.
- Ensured the grouped session card uses the first student’s topic as the main session topic.
- Added backend support for saving booking topics and requiring a non-empty topic on new bookings.
- Added grouped lecturer session cancellation so canceling one grouped session cancels it for all joined students and the lecturer.
- Reworked the lecturer session details modal to avoid Bootstrap modal class conflicts.
- Improved lecturer dashboard button handling for dynamically rendered session cards.

## Testing

- Added and updated lecturer dashboard tests for:
  - Grouping multiple student bookings into one session card
  - Showing all joined students in session details
  - Showing each student’s topic in the details list
  - Displaying a `Topic` heading
  - Canceling grouped sessions for all participants

- Added and updated booking tests for:
  - Persisting booking topics
  - Requiring a topic when creating bookings
  - Canceling grouped booking sessions through the backend


