### PR TITLE
fix: add role-specific activity logs

### DIFF
--- a/public/activity-log.html
+++ b/public/activity-log.html
@@ -4,180 +4,34 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Activity Log</title>
-    <link rel="stylesheet" href="css/activity-log.css">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
-    <div class="activity-container">
-        <!-- Header -->
-        <header class="activity-header">
-            <div class="header-left">
-                <h1>
-                    <i class="fas fa-history"></i>Activity Log
-                </h1>
-                <p class="header-subtitle">All System Actions</p>
-            </div>
-            <div class="header-right">
-                <button id="auto-refresh-toggle" class="btn btn-outline" title="Auto-refresh every 10 seconds">
-                    <i class="fas fa-sync-alt"></i>
-                    <span>Auto-refresh</span>
-                </button>
-            </div>
-        </header>
+    <script>
+        (function () {
+            function readUser() {
+                try {
+                    return JSON.parse(
+                        sessionStorage.getItem('sychro_current_user') ||
+                        localStorage.getItem('sychro_current_user') ||
+                        '{}'
+                    );
+                } catch (error) {
+                    return {};
+                }
+            }
 
-        <!-- Stats Bar -->
-        <div class="stats-bar">
-            <div class="stat-item">
-                <i class="fas fa-list"></i>
-                <span>Total Activities: <strong id="total-activities">0</strong></span>
-            </div>
-            <div class="stat-item">
-                <i class="fas fa-clock"></i>
-                <span>Today: <strong id="today-activities">0</strong></span>
-            </div>
-            <div class="stat-item">
-                <i class="fas fa-exclamation-circle"></i>
-                <span>Errors: <strong id="error-activities">0</strong></span>
-            </div>
-            <div class="stat-item">
-                <i class="fas fa-user"></i>
-                <span>Users Active: <strong id="active-users">0</strong></span>
-            </div>
-        </div>
+            var params = new URLSearchParams(window.location.search);
+            var requestedRole = params.get('role');
+            var user = readUser();
+            var role = (requestedRole || user.role || '').toLowerCase();
 
-        <!-- Filters -->
-        <div class="filters-section">
-            <div class="filter-row">
-                <div class="filter-group">
-    <label for="action-type-filter">
-        <i class="fas fa-tag"></i> Action Type
-    </label>
-    <select id="action-type-filter" class="filter-select">
-        <option value="all">All Actions</option>
-        <option value="created">Created</option>
-        <option value="joined">Joined</option>
-        <option value="canceled">Canceled</option>
-    </select>
-</div>
+            if (role === 'lecturer') {
+                window.location.replace('/lecturer-activity-log.html');
+                return;
+            }
 
-                <div class="filter-group">
-                    <label for="user-filter">
-                        <i class="fas fa-user"></i> User
-                    </label>
-                    <select id="user-filter" class="filter-select">
-                        <option value="all">All Users</option>
-                    </select>
-                </div>
-
-                <div class="filter-group">
-                    <label for="date-range-filter">
-                        <i class="fas fa-calendar"></i> Date Range
-                    </label>
-                    <select id="date-range-filter" class="filter-select">
-                        <option value="all">All Time</option>
-                        <option value="today">Today</option>
-                        <option value="yesterday">Yesterday</option>
-                        <option value="last7">Last 7 Days</option>
-                        <option value="last30">Last 30 Days</option>
-                        <option value="custom">Custom Range</option>
-                    </select>
-                </div>
-
-                <div class="filter-group custom-date-range hidden" id="custom-date-range">
-                    <input type="date" id="start-date" class="date-input">
-                    <span>to</span>
-                    <input type="date" id="end-date" class="date-input">
-                    <button id="apply-date-range" class="btn btn-sm btn-primary">Apply</button>
-                </div>
-            </div>
-                <div class = "filter-group">
-                    <label for = "course-filter">  
-                    </label>
-                    <select id = "course-filter" class = "filter-select">
-                        <option value = "all">All Courses</option>
-                    </select>
-                </div>
-
-            <div class="filter-row">
-                <div class="filter-group flex-grow">
-                    <label for="search-input">
-                        <i class="fas fa-search"></i> Search
-                    </label>
-                    <input 
-                        type="text" 
-                        id="search-input" 
-                        class="search-input" 
-                        placeholder="Search by description, user, or consultation ID..."
-                    >
-                </div>
-
-                <div class="filter-actions">
-                    <button id="clear-filters-btn" class="btn btn-outline btn-sm">
-                        <i class="fas fa-times"></i> Clear Filters
-                    </button>
-                    <button id="export-activity-btn" class="btn btn-secondary btn-sm">
-                        <i class="fas fa-download"></i> Export CSV
-                    </button>
-                    <button id="bookmark-btn" class="btn btn-outline btn-sm" title="Copy shareable link">
-                        <i class="fas fa-bookmark"></i> Copy Link
-                     </button>
-                    <button id="clear-all-btn" class="btn btn-danger btn-sm">
-                        <i class="fas fa-trash"></i> Clear All Logs
-                    </button>
-                </div>
-            </div>
-        </div>
-
-        <!-- Activity Timeline -->
-        <div class="activity-timeline-container">
-            <div id="activity-timeline" class="activity-timeline">
-                <!-- Activities will be inserted here -->
-            </div>
-
-            <!-- Empty State -->
-            <div id="empty-state" class="empty-state hidden">
-                <i class="fas fa-clipboard-list"></i>
-                <h3>No Activity Recorded</h3>
-                <p>Actions performed in the consultation log will appear here automatically.</p>
-                <button id="generate-sample-btn" class="btn btn-primary">
-                    <i class="fas fa-magic"></i> Generate Sample Activity
-                </button>
-            </div>
-
-            <!-- Loading Indicator -->
-            <div id="loading-indicator" class="loading-indicator hidden">
-                <i class="fas fa-spinner fa-spin"></i>
-                <span>Loading activities...</span>
-            </div>
-        </div>
-
-        <!-- Pagination -->
-        <div class="pagination" id="pagination">
-            <button id="prev-page" class="btn btn-outline btn-sm" disabled>
-                <i class="fas fa-chevron-left"></i> Previous
-            </button>
-            <span class="page-info">
-                Page <strong id="current-page">1</strong> of <strong id="total-pages">1</strong>
-            </span>
-            <button id="next-page" class="btn btn-outline btn-sm" disabled>
-                Next <i class="fas fa-chevron-right"></i>
-            </button>
-        </div>
-    </div>
-
-    <!-- Activity Detail Modal -->
-    <div id="detail-modal" class="modal hidden">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h2>Activity Details</h2>
-                <button class="close-btn" id="close-detail-modal">&times;</button>
-            </div>
-            <div id="detail-content" class="detail-body">
-                <!-- Dynamic content -->
-            </div>
-        </div>
-    </div>
-
-    <script src="js/activity-log.js"></script>
+            window.location.replace('/student-activity-log.html');
+        })();
+    </script>
 </body>
 </html>

--- a/public/css/students-joining.css
+++ b/public/css/students-joining.css
@@ -86,6 +86,12 @@ body {
 
 .btn-success:hover { background: #059669; }
 
+.btn-disabled {
+    background: rgba(255,255,255,0.25);
+    color: rgba(255,255,255,0.65);
+    cursor: not-allowed;
+}
+
 .btn-sm { height: 30px; font-size: 12px; padding: 0 15px; }
 
 /* Filters */
@@ -236,6 +242,22 @@ body {
 .attendee-count {
     font-size: 12px;
     color: rgba(255,255,255,0.5);
+}
+
+.space-count {
+    font-size: 12px;
+    color: #b7f7c3;
+    font-weight: 700;
+    background: rgba(16,185,129,0.14);
+    border: 1px solid rgba(16,185,129,0.25);
+    border-radius: 999px;
+    padding: 3px 8px;
+}
+
+.space-count.full {
+    color: #ffd0d0;
+    background: rgba(255,77,77,0.14);
+    border-color: rgba(255,77,77,0.25);
 }
 
 .join-btn {

--- a/public/js/activity-log.js
+++ b/public/js/activity-log.js
@@ -10,6 +10,9 @@ class ActivityLogManager {
     }
 
     async init() {
+        this.currentUser = this.getCurrentUser();
+        this.logRole = this.getLogRole();
+        this.applyRoleLabels();
         await this.loadActivities();
         this.setupEventListeners();
         this.updateStats();
@@ -96,9 +99,11 @@ class ActivityLogManager {
     // DATA MANAGEMENT
  async loadActivities() {
         try {
-            const response = await fetch(this.apiBase);
+            const headers = this.getUserHeaders();
+            const response = headers ? await fetch(this.apiBase, { headers }) : await fetch(this.apiBase);
             if (response.ok) {
-                this.activities = await response.json();
+                const activities = await response.json();
+                this.activities = activities.map(activity => this.normalizeActivity(activity));
             } else {
                 this.activities = [];
             }
@@ -110,14 +115,51 @@ class ActivityLogManager {
     
     async logAction(type, description, metadata = {}) {
         const currentUser = this.getCurrentUser();
+        this.currentUser = currentUser;
+        const userId = currentUser.idNumber || currentUser.id || currentUser.email || null;
+        const userEmail = currentUser.email || userId || null;
+        const userRole = currentUser.role || this.logRole || '';
+        const roleMetadata = userRole === 'lecturer'
+            ? {
+                lecturerId: metadata.lecturerId || userId,
+                lecturerEmail: metadata.lecturerEmail || userEmail
+            }
+            : userRole === 'student'
+                ? {
+                    studentId: metadata.studentId || userId,
+                    studentEmail: metadata.studentEmail || userEmail
+                }
+                : {};
 
         const entry = {
             type: type,
             description: description,
-            user: currentUser.fullName || currentUser.email || 'Unknown User',
-            userId: currentUser.id || null,
+            user: this.getDisplayName(currentUser),
+            userId,
+            userEmail,
+            userRole,
             timestamp: new Date().toISOString(),
-            metadata: metadata
+            metadata: {
+                ...metadata,
+                ...roleMetadata,
+                userId: metadata.userId || userId,
+                userEmail: metadata.userEmail || userEmail,
+                actorId: metadata.actorId || userId,
+                actorEmail: metadata.actorEmail || userEmail,
+                userRole,
+                audienceIds: [...new Set([
+                    ...(Array.isArray(metadata.audienceIds) ? metadata.audienceIds : []),
+                    userId,
+                    roleMetadata.studentId,
+                    roleMetadata.lecturerId
+                ].filter(Boolean))],
+                audienceEmails: [...new Set([
+                    ...(Array.isArray(metadata.audienceEmails) ? metadata.audienceEmails : []),
+                    userEmail,
+                    roleMetadata.studentEmail,
+                    roleMetadata.lecturerEmail
+                ].filter(Boolean))]
+            }
         };
         
       try {
@@ -139,30 +181,106 @@ class ActivityLogManager {
     }
 
     getCurrentUser() {
-        // Check sessionStorage first (cleared when browser closes)
-        const sessionUser = sessionStorage.getItem('sychro_current_user');
-        if (sessionUser) {
-            return JSON.parse(sessionUser);
+        try {
+            const sessionUser = sessionStorage.getItem('sychro_current_user');
+            if (sessionUser) {
+                return JSON.parse(sessionUser);
+            }
+
+            const localUser = localStorage.getItem('sychro_current_user');
+            if (localUser) {
+                return JSON.parse(localUser);
+            }
+        } catch (error) {
+            console.error('Failed to read current user:', error);
         }
 
-        // Check localStorage (persists across sessions)
-        const localUser = localStorage.getItem('sychro_current_user');
-        if (localUser) {
-            return JSON.parse(localUser);
+        const rememberedEmail = localStorage.getItem('userEmail');
+        if (rememberedEmail) {
+            return { fullName: rememberedEmail, email: rememberedEmail, id: rememberedEmail };
         }
 
         return { fullName: 'System', email: 'system', id: null };
     }
 
+    getLogRole() {
+        const pageRole = document.body.dataset.logRole;
+        if (pageRole && pageRole !== 'auto') return pageRole;
+        const path = window.location.pathname.toLowerCase();
+        if (path.includes('lecturer')) return 'lecturer';
+        if (path.includes('student')) return 'student';
+        return (this.currentUser && this.currentUser.role) || 'activity';
+    }
+
+    applyRoleLabels() {
+        const labels = {
+            lecturer: {
+                title: 'Lecturer Activity Log',
+                subtitle: 'Your availability and consultation activity',
+                emptyTitle: 'No Lecturer Activity Recorded',
+                emptyMessage: 'Availability changes and consultation bookings involving you will appear here.'
+            },
+            student: {
+                title: 'Student Activity Log',
+                subtitle: 'Your booking and consultation activity',
+                emptyTitle: 'No Student Activity Recorded',
+                emptyMessage: 'Bookings and consultation changes involving you will appear here.'
+            },
+            activity: {
+                title: 'Activity Log',
+                subtitle: 'Your consultation activity',
+                emptyTitle: 'No Activity Recorded',
+                emptyMessage: 'Actions performed in the consultation log will appear here automatically.'
+            }
+        };
+        const label = labels[this.logRole] || labels.activity;
+        const title = document.getElementById('activity-log-title');
+        const subtitle = document.getElementById('activity-log-subtitle');
+        const emptyTitle = this.emptyState ? this.emptyState.querySelector('h3') : null;
+        const emptyMessage = document.getElementById('empty-state-message');
+
+        document.title = label.title;
+        if (title) title.textContent = label.title;
+        if (subtitle) subtitle.textContent = label.subtitle;
+        if (emptyTitle) emptyTitle.textContent = label.emptyTitle;
+        if (emptyMessage) emptyMessage.textContent = label.emptyMessage;
+    }
+
+    normalizeActivity(activity) {
+        const metadata = activity.metadata || {};
+        return {
+            ...activity,
+            id: activity.id || activity._id,
+            user: activity.user || activity.userEmail || metadata.actorEmail || metadata.studentEmail || metadata.lecturerEmail || 'Unknown User',
+            description: activity.description || 'Activity recorded',
+            metadata
+        };
+    }
+
+    getDisplayName(user) {
+        if (!user) return 'Unknown User';
+        const fullName = [user.name, user.surname].filter(Boolean).join(' ').trim();
+        return user.fullName || fullName || user.email || 'Unknown User';
+    }
+
+    getUserHeaders() {
+        const user = this.currentUser || this.getCurrentUser();
+        if (!user || user.email === 'system') return null;
+        const id = user.idNumber || user.id || user.email || '';
+        return {
+            'X-User-Email': user.email || '',
+            'X-User-Id': id,
+            'X-User-Role': user.role || this.logRole || ''
+        };
+    }
+
     async clearAll() {
-        if (confirm('Delete ALL activity logs? This cannot be undone.')) {
+        if (confirm('Delete your activity logs? This cannot be undone.')) {
             try {
-            await fetch(this.apiBase, { method: 'DELETE' });
-            this.activities = [];
-            this.updateStats();
-            this.updateFilterOptions();
-            this.applyFilters();
-                const response = await fetch(this.apiBase, { method: 'DELETE' });
+                const headers = this.getUserHeaders();
+                const response = await fetch(this.apiBase, headers
+                    ? { method: 'DELETE', headers }
+                    : { method: 'DELETE' });
                 if (!response.ok) throw new Error('Failed to clear activities');
 
                 this.activities = [];
@@ -188,7 +306,7 @@ class ActivityLogManager {
         this.filteredActivities = this.activities.filter(activity => {
             if (actionType !== 'all' && activity.type !== actionType) return false;
             if (user !== 'all' && activity.user !== user) return false;
-            if (course !== 'all' && activity.metadata.course !== course) return false;
+            if (course !== 'all' && (activity.metadata || {}).course !== course) return false;
         
             if (dateRange !== 'all') {
                 const activityDate = new Date(activity.timestamp);
@@ -220,7 +338,19 @@ class ActivityLogManager {
             }
 
             if (searchTerm) {
-                const searchStr = (activity.description + ' ' + activity.user).toLowerCase();
+                const metadata = activity.metadata || {};
+                const searchStr = [
+                    activity.description,
+                    activity.user,
+                    metadata.course,
+                    metadata.module,
+                    metadata.venue,
+                    metadata.topic,
+                    metadata.studentName,
+                    metadata.studentId,
+                    metadata.lecturerName,
+                    metadata.lecturerId
+                ].filter(Boolean).join(' ').toLowerCase();
                 if (!searchStr.includes(searchTerm)) return false;
             }
 
@@ -243,8 +373,8 @@ class ActivityLogManager {
     }
 
     updateFilterOptions() {
-        const users = [...new Set(this.activities.map(a => a.user))].sort();
-        this.userFilter.innerHTML = '<option value="all">All Users</option>';
+        const users = [...new Set(this.activities.map(a => a.user).filter(Boolean))].sort();
+        this.userFilter.innerHTML = '<option value="all">All Relevant People</option>';
         users.forEach(user => {
             const option = document.createElement('option');
             option.value = user;
@@ -252,7 +382,7 @@ class ActivityLogManager {
             this.userFilter.appendChild(option);
         });
 
-        const courses = [...new Set(this.activities.map(a => a.metadata.course))].sort();
+        const courses = [...new Set(this.activities.map(a => (a.metadata || {}).course).filter(Boolean))].sort();
         this.courseFilter.innerHTML = '<option value="all">All Courses</option>';
         courses.forEach(course => {
             const option = document.createElement('option');
@@ -348,9 +478,37 @@ class ActivityLogManager {
                 <span class="detail-label">Timestamp</span>
                 <span class="detail-value">${time}</span>
             </div>
+            ${this.renderMetadata(activity.metadata || {})}
         `;
 
         this.detailModal.classList.remove('hidden');
+    }
+
+    renderMetadata(metadata) {
+        const rows = [
+            ['Course', metadata.course || metadata.module],
+            ['Date', metadata.date],
+            ['Time', metadata.time || [metadata.startTime, metadata.endTime].filter(Boolean).join(' - ')],
+            ['Venue', metadata.venue],
+            ['Lecturer', metadata.lecturerName || metadata.lecturerId || metadata.lecturerEmail],
+            ['Student', metadata.studentName || metadata.studentId || metadata.studentEmail],
+            ['Topic', metadata.topic]
+        ].filter(([, value]) => value);
+
+        if (rows.length === 0) return '';
+
+        return `
+            <div class="detail-row">
+                <span class="detail-label">Relevant Details</span>
+                <span class="detail-value"></span>
+            </div>
+            ${rows.map(([label, value]) => `
+                <div class="detail-row">
+                    <span class="detail-label">${this.escape(label)}</span>
+                    <span class="detail-value">${this.escape(value)}</span>
+                </div>
+            `).join('')}
+        `;
     }
 
     closeModal() {
@@ -371,12 +529,16 @@ class ActivityLogManager {
     // EXPORT
 
     exportCSV() {
-        const headers = ['Timestamp', 'Type', 'User', 'Description'];
+        const headers = ['Timestamp', 'Type', 'User', 'Description', 'Course', 'Date', 'Time', 'Venue'];
         const rows = this.filteredActivities.map(a => [
             new Date(a.timestamp).toLocaleString(),
             a.type,
             a.user,
-            a.description
+            a.description,
+            (a.metadata || {}).course || '',
+            (a.metadata || {}).date || '',
+            (a.metadata || {}).time || (a.metadata || {}).startTime || '',
+            (a.metadata || {}).venue || ''
         ]);
 
         const csv = [headers.join(','), ...rows.map(r => r.map(c => `"${c}"`).join(','))].join('\n');
@@ -384,7 +546,7 @@ class ActivityLogManager {
         const url = URL.createObjectURL(blob);
         const link = document.createElement('a');
         link.href = url;
-        link.download = `activity-log-${new Date().toISOString().split('T')[0]}.csv`;
+        link.download = `${this.logRole || 'activity'}-activity-log-${new Date().toISOString().split('T')[0]}.csv`;
         link.click();
         URL.revokeObjectURL(url);
     }
@@ -431,6 +593,7 @@ class ActivityLogManager {
         const icons = {
             created: 'fa-plus-circle',
             joined: 'fa-sign-in-alt',
+            updated: 'fa-pen-to-square',
             canceled: 'fa-times-circle'
         };
         return icons[type] || 'fa-circle';
@@ -440,6 +603,7 @@ class ActivityLogManager {
         const classes = {
             created: 'icon-create',
             joined: 'icon-join',
+            updated: 'icon-filter',
             canceled: 'icon-cancel'
         };
         return classes[type] || 'icon-filter';

--- a/public/js/booking-page.js
+++ b/public/js/booking-page.js
@@ -101,7 +101,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       matchingLecturers.forEach(lecturer => {
         const option = document.createElement('option')
-        option.value = lecturer.lecturerName
+        option.value = lecturer.lecturerEmail || lecturer.lecturerName
         option.textContent = lecturer.lecturerName || lecturer.lecturerEmail
         lecturerSelect.appendChild(option)
       })

--- a/public/js/booking-page.js
+++ b/public/js/booking-page.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const selectedEndInput = document.getElementById('selectedEndTime')
   const newBookingForm = document.getElementById('newBookingForm')
   let selectedVenue = ''
+  let selectedMaxStudents = 1
 
   // Set minimum date to today to prevent past bookings
   const today = new Date().toISOString().split('T')[0]
@@ -140,7 +141,7 @@ document.addEventListener('DOMContentLoaded', () => {
           // Calculate how many bookings currently exist for this exact start time
           const currentBookingsCount = data.bookedTimes.filter(time => time === slot.start).length
 
-          const hasSpace = currentBookingsCount === 0
+          const hasSpace = currentBookingsCount < (Number(slot.maxStudents) || 1)
 
           return isCorrectModule && hasSpace
         })
@@ -161,6 +162,7 @@ document.addEventListener('DOMContentLoaded', () => {
     selectedStartInput.value = '';
     selectedEndInput.value = '';
     selectedVenue = '';
+    selectedMaxStudents = 1;
 
     if (slotsArray.length === 0) {
       slotsContainer.innerHTML = '<div class="text-danger small">No available slots for this module on this date.</div>'
@@ -175,7 +177,8 @@ document.addEventListener('DOMContentLoaded', () => {
       // Safe check for duration
       const durationText = slot.duration ? `<br><small class="text-muted">${slot.duration} min</small>` : '';
       const venueText = slot.venue ? `<br><small class="text-muted">${slot.venue}</small>` : '';
-      btn.innerHTML = `${slot.start} - ${slot.end} ${durationText}${venueText}`;
+      const capacityText = slot.maxStudents ? `<br><small class="text-muted">${slot.maxStudents} max students</small>` : '';
+      btn.innerHTML = `${slot.start} - ${slot.end} ${durationText}${venueText}${capacityText}`;
 
       btn.onclick = () => {
         document.querySelectorAll('.slot-btn').forEach(b => b.classList.remove('active'))
@@ -184,6 +187,7 @@ document.addEventListener('DOMContentLoaded', () => {
         selectedStartInput.value = slot.start;
         selectedEndInput.value = slot.end;
         selectedVenue = slot.venue || '';
+        selectedMaxStudents = Number(slot.maxStudents) || 1;
       };
 
       slotsContainer.appendChild(btn)
@@ -218,6 +222,7 @@ document.addEventListener('DOMContentLoaded', () => {
         startTime: selectedStartInput.value,
         endTime: selectedEndInput.value,
         venue: selectedVenue,
+        maxStudents: selectedMaxStudents,
         participantIDs: [user.email],
         topic: document.getElementById('topic') ? document.getElementById('topic').value : ''
       }

--- a/public/js/lecturer-dashboard.js
+++ b/public/js/lecturer-dashboard.js
@@ -233,13 +233,36 @@ class LecturerScheduleManager {
             return true;
         });
 
-        this.filteredSessions.sort((a, b) => {
-            const dateA = new Date(`${a.date}T${a.time}`);
-            const dateB = new Date(`${b.date}T${b.time}`);
-            return dateA - dateB;
-        });
+        this.filteredSessions.sort((a, b) => this.compareDashboardSessions(a, b));
 
         this.render();
+    }
+
+    compareDashboardSessions(a, b) {
+        const statusPriority = {
+            ongoing: 1,
+            upcoming: 2,
+            completed: 3,
+            canceled: 4
+        };
+        const priorityA = statusPriority[a.status] || 99;
+        const priorityB = statusPriority[b.status] || 99;
+
+        if (priorityA !== priorityB) return priorityA - priorityB;
+
+        const timeA = this.getSessionStartTime(a);
+        const timeB = this.getSessionStartTime(b);
+
+        if (a.status === 'completed' || a.status === 'canceled') {
+            return timeB - timeA;
+        }
+
+        return timeA - timeB;
+    }
+
+    getSessionStartTime(session) {
+        const timestamp = new Date(`${session.date}T${session.time}`).getTime();
+        return Number.isNaN(timestamp) ? Number.MAX_SAFE_INTEGER : timestamp;
     }
 
     updateFilterOptions() {

--- a/public/js/student-dashboard.js
+++ b/public/js/student-dashboard.js
@@ -196,37 +196,36 @@ class StudentScheduleManager {
       return true
     })
 
-    // NEW SORTING LOGIC: Priority by Status, then by Date
+    this.filteredSessions.sort((a, b) => this.compareDashboardSessions(a, b))
+
+    this.render()
+  }
+
+  compareDashboardSessions (a, b) {
     const statusPriority = {
       ongoing: 1,
       upcoming: 2,
       completed: 3,
       canceled: 4
     }
+    const priorityA = statusPriority[a.status] || 99
+    const priorityB = statusPriority[b.status] || 99
 
-    this.filteredSessions.sort((a, b) => {
-      const priorityA = statusPriority[a.status] || 99
-      const priorityB = statusPriority[b.status] || 99
+    if (priorityA !== priorityB) return priorityA - priorityB
 
-      // If statuses are different, sort by priority
-      if (priorityA !== priorityB) {
-        return priorityA - priorityB
-      }
+    const timeA = this.getSessionStartTime(a)
+    const timeB = this.getSessionStartTime(b)
 
-      // If statuses are the same, sort by date/time
-      const dateA = new Date(`${a.date}T${a.time}`)
-      const dateB = new Date(`${b.date}T${b.time}`)
+    if (a.status === 'completed' || a.status === 'canceled') {
+      return timeB - timeA
+    }
 
-      // For completed/canceled things, show the newest ones first
-      if (a.status === 'completed' || a.status === 'canceled') {
-        return dateB - dateA
-      }
+    return timeA - timeB
+  }
 
-      // For upcoming things, show the nearest ones first
-      return dateA - dateB
-    })
-
-    this.render()
+  getSessionStartTime (session) {
+    const timestamp = new Date(`${session.date}T${session.time}`).getTime()
+    return Number.isNaN(timestamp) ? Number.MAX_SAFE_INTEGER : timestamp
   }
 
   updateFilterOptions () {
@@ -287,9 +286,6 @@ class StudentScheduleManager {
                 </div>
                 <span class="session-status ${statusClass}">${session.status || 'unknown'}</span>
                 <div class="session-actions">
-                    <button class="btn btn-sm btn-outline" onclick="scheduleManager.showDetail('${session.id}')">
-                        <i class="fas fa-info-circle"></i> Details
-                    </button>
                     ${session.status === 'upcoming'
 ? `
                         <button class="btn btn-sm btn-danger" onclick="scheduleManager.cancelBooking('${session.id}')">

--- a/public/js/students-joining.js
+++ b/public/js/students-joining.js
@@ -5,16 +5,19 @@ class StudentSessionJoiner {
         this.sessions = [];
         this.filteredSessions = [];
         this.currentStudent = null;
+        this.availableCourses = [];
 
         this.init();
     }
 
     init() {
         this.loadCurrentStudent();
-        this.loadSessions();
+        this.loadLocalSessions();
         this.setupEventListeners();
         this.updateFilterOptions();
-        this.render();
+        this.filterAndRender();
+        this.loadCourseOptions();
+        this.loadSessions();
     }
 
     // DOM getters
@@ -26,8 +29,6 @@ class StudentSessionJoiner {
     setupEventListeners() {
         document.getElementById('refresh-btn').addEventListener('click', () => {
             this.loadSessions();
-            this.updateFilterOptions();
-            this.render();
         });
         this.courseFilter.addEventListener('change', () => this.filterAndRender());
         this.searchInput.addEventListener('input', this.debounce(() => this.filterAndRender(), 300));
@@ -44,11 +45,146 @@ class StudentSessionJoiner {
         }
     }
 
-    loadSessions() {
+    loadLocalSessions() {
         const stored = localStorage.getItem(this.storageKey);
         const allSessions = stored ? JSON.parse(stored) : [];
-        // Show only upcoming/ongoing sessions, not canceled/completed
-        this.sessions = allSessions.filter(s => s.status === 'upcoming' || s.status === 'ongoing');
+        this.sessions = allSessions
+            .filter(s => s.status === 'upcoming' || s.status === 'ongoing')
+            .map(s => ({
+                ...s,
+                source: 'local',
+                maxStudents: Number(s.maxStudents) || Number(s.capacity) || 5,
+                joinedStudents: s.joinedStudents || [],
+                joinedStudentIds: s.joinedStudentIds || s.participantIDs || s.joinedStudents || []
+            }));
+    }
+
+    async loadSessions() {
+        if (typeof fetch !== 'function') return;
+
+        try {
+            const response = await fetch('/api/bookings?status=upcoming,ongoing');
+            if (!response.ok) return;
+
+            const bookings = await response.json();
+            this.sessions = bookings
+                .map(booking => this.mapBookingToSession(booking))
+                .filter(session => this.isJoinablePeerSession(session));
+            this.updateFilterOptions();
+            this.filterAndRender();
+        } catch (error) {
+            console.error('Failed to load peer sessions:', error);
+        }
+    }
+
+    async loadCourseOptions() {
+        if (typeof fetch !== 'function') {
+            this.availableCourses = this.collectSessionCourses();
+            this.updateFilterOptions();
+            return;
+        }
+
+        try {
+            const response = await fetch('/api/bookings/form-data');
+            if (!response.ok) return;
+
+            const lecturers = await response.json();
+            const courses = this.collectSessionCourses();
+            lecturers.forEach(lecturer => {
+                (lecturer.courses || []).forEach(course => courses.push(course));
+                (lecturer.weeklySchedule || []).forEach(day => {
+                    (day.slots || []).forEach(slot => {
+                        if (slot.course) courses.push(slot.course);
+                    });
+                });
+            });
+            this.availableCourses = [...new Set(courses.filter(Boolean).map(String))].sort();
+            this.updateFilterOptions();
+        } catch (error) {
+            this.availableCourses = this.collectSessionCourses();
+            this.updateFilterOptions();
+        }
+    }
+
+    collectSessionCourses() {
+        return this.sessions.map(s => s.courseCode).filter(Boolean);
+    }
+
+    mapBookingToSession(booking) {
+        const joinedStudentIds = booking.participantIDs || [];
+        const joinedStudents = booking.participantNames || joinedStudentIds;
+        return {
+            id: booking._id || booking.id,
+            source: 'api',
+            courseCode: booking.module || booking.courseCode,
+            date: booking.date,
+            time: booking.startTime || booking.time,
+            endTime: booking.endTime,
+            duration: booking.duration || this.calculateDuration(booking.startTime, booking.endTime),
+            status: booking.status || 'upcoming',
+            studentName: booking.studentName || booking.studentId || 'Student',
+            studentId: booking.studentId,
+            topic: booking.topic || 'No topic',
+            lecturerName: booking.lecturerName || booking.lecturerId || '',
+            joinedStudents,
+            joinedStudentIds,
+            maxStudents: Number(booking.effectiveMaxStudents || booking.maxStudents) || 1,
+            spacesLeft: Number.isFinite(Number(booking.spacesLeft)) ? Number(booking.spacesLeft) : undefined,
+            venue: booking.venue || ''
+        };
+    }
+
+    calculateDuration(start, end) {
+        if (!start || !end) return '';
+        const [startHour, startMinute] = start.split(':').map(Number);
+        const [endHour, endMinute] = end.split(':').map(Number);
+        return ((endHour * 60) + endMinute) - ((startHour * 60) + startMinute);
+    }
+
+    isJoinablePeerSession(session) {
+        if (!session.id || !['upcoming', 'ongoing'].includes(session.status)) return false;
+        if (this.isSessionFull(session)) return false;
+        if (this.hasSessionPassed(session)) return false;
+        const currentIds = this.getCurrentStudentIds();
+        if (currentIds.some(id => id && id === session.studentId)) return false;
+        return true;
+    }
+
+    isSessionFull(session) {
+        const joinedIds = session.joinedStudentIds || session.joinedStudents || [];
+        const maxStudents = Number(session.maxStudents) || 1;
+        const spacesLeft = Number.isFinite(Number(session.spacesLeft))
+            ? Number(session.spacesLeft)
+            : maxStudents - joinedIds.length;
+        return spacesLeft <= 0;
+    }
+
+    hasSessionPassed(session) {
+        if (!session.date) return false;
+        const sessionEnd = session.endTime || session.time;
+        const timestamp = new Date(`${session.date}T${sessionEnd}`).getTime();
+        if (Number.isNaN(timestamp)) return false;
+        return timestamp < Date.now();
+    }
+
+    getCurrentStudentIds() {
+        if (!this.currentStudent) return [];
+        return [
+            this.currentStudent.email,
+            this.currentStudent.id,
+            this.currentStudent.idNumber,
+            this.currentStudent.fullName,
+            [this.currentStudent.name, this.currentStudent.surname].filter(Boolean).join(' ')
+        ].filter(Boolean);
+    }
+
+    getCurrentStudentLabel() {
+        if (!this.currentStudent) return '';
+        return this.currentStudent.fullName ||
+            [this.currentStudent.name, this.currentStudent.surname].filter(Boolean).join(' ') ||
+            this.currentStudent.email ||
+            this.currentStudent.idNumber ||
+            '';
     }
 
     filterAndRender() {
@@ -56,20 +192,33 @@ class StudentSessionJoiner {
         const searchTerm = this.searchInput.value.toLowerCase().trim();
 
         this.filteredSessions = this.sessions.filter(session => {
+            if (!this.isJoinablePeerSession(session)) return false;
             if (course !== 'all' && session.courseCode !== course) return false;
             if (searchTerm) {
-                const searchStr = `${session.studentName} ${session.topic} ${session.courseCode}`.toLowerCase();
+                const searchStr = `${session.studentName} ${session.topic} ${session.courseCode} ${session.lecturerName} ${session.venue}`.toLowerCase();
                 if (!searchStr.includes(searchTerm)) return false;
             }
             return true;
         });
 
-        this.filteredSessions.sort((a, b) => new Date(`${a.date}T${a.time}`) - new Date(`${b.date}T${b.time}`));
+        this.filteredSessions.sort((a, b) => this.compareSoonestSessions(a, b));
         this.render();
     }
 
+    compareSoonestSessions(a, b) {
+        if (a.status === 'ongoing' && b.status !== 'ongoing') return -1;
+        if (b.status === 'ongoing' && a.status !== 'ongoing') return 1;
+        return this.getSessionStartTime(a) - this.getSessionStartTime(b);
+    }
+
+    getSessionStartTime(session) {
+        const timestamp = new Date(`${session.date}T${session.time}`).getTime();
+        return Number.isNaN(timestamp) ? Number.MAX_SAFE_INTEGER : timestamp;
+    }
+
     updateFilterOptions() {
-        const courses = [...new Set(this.sessions.map(s => s.courseCode).filter(Boolean))].sort();
+        const currentValue = this.courseFilter.value || 'all';
+        const courses = [...new Set([...this.availableCourses, ...this.collectSessionCourses()].filter(Boolean))].sort();
         this.courseFilter.innerHTML = '<option value="all">All Courses</option>';
         courses.forEach(course => {
             const option = document.createElement('option');
@@ -77,6 +226,7 @@ class StudentSessionJoiner {
             option.textContent = course;
             this.courseFilter.appendChild(option);
         });
+        if (courses.includes(currentValue)) this.courseFilter.value = currentValue;
     }
 
     render() {
@@ -94,17 +244,21 @@ class StudentSessionJoiner {
         const dateDisplay = dateObj.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
         const timeDisplay = dateObj.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
         const joinedStudents = session.joinedStudents || [];
-        const totalJoined = joinedStudents.length;
-
-        // Check if current student already joined
-        const alreadyJoined = this.currentStudent && joinedStudents.includes(this.currentStudent.fullName);
+        const joinedStudentIds = session.joinedStudentIds || joinedStudents;
+        const totalJoined = joinedStudentIds.length;
+        const maxStudents = Number(session.maxStudents) || 1;
+        const spacesLeft = Number.isFinite(Number(session.spacesLeft))
+            ? Math.max(Number(session.spacesLeft), 0)
+            : Math.max(maxStudents - totalJoined, 0);
+        const isFull = spacesLeft === 0;
+        const alreadyJoined = this.getCurrentStudentIds().some(id => joinedStudentIds.includes(id) || joinedStudents.includes(id));
 
         return `
             <div class="session-card">
                 <div class="session-time">
                     <div class="date">${dateDisplay}</div>
                     <div class="time">${timeDisplay}</div>
-                    <div style="font-size:12px;color:rgba(255,255,255,0.5)">${session.duration}min</div>
+                    <div style="font-size:12px;color:rgba(255,255,255,0.5)">${session.duration || ''}min</div>
                 </div>
                 <div class="session-info">
                     <div class="session-course">${this.escape(session.courseCode)}</div>
@@ -113,48 +267,104 @@ class StudentSessionJoiner {
                         <i class="fas fa-user-circle"></i> Created by ${this.escape(session.studentName)}
                         ${session.lecturerName ? ` with ${this.escape(session.lecturerName)}` : ''}
                     </div>
+                    ${session.venue ? `<div class="session-owner"><i class="fas fa-location-dot"></i> ${this.escape(session.venue)}</div>` : ''}
                     <div class="attendees">
                         ${joinedStudents.slice(0, 4).map(name => 
-                            `<div class="attendee-avatar" title="${this.escape(name)}">${name.split(' ').map(n => n[0]).join('')}</div>`
+                            `<div class="attendee-avatar" title="${this.escape(name)}">${this.escape(this.initials(name))}</div>`
                         ).join('')}
                         ${totalJoined > 4 ? `<div class="attendee-avatar">+${totalJoined - 4}</div>` : ''}
-                        <span class="attendee-count">${totalJoined} joined</span>
+                        <span class="attendee-count">${totalJoined}/${maxStudents} joined</span>
+                        <span class="space-count ${isFull ? 'full' : ''}">${spacesLeft} ${spacesLeft === 1 ? 'space' : 'spaces'} left</span>
                     </div>
                 </div>
                 <div class="join-btn">
                     ${alreadyJoined ? 
                         `<button class="btn btn-success btn-sm" disabled><i class="fas fa-check"></i> Joined</button>` :
-                        `<button class="btn btn-sm" onclick="studentJoiner.joinSession('${session.id}')"><i class="fas fa-plus"></i> Join</button>`
+                        isFull ?
+                            `<button class="btn btn-sm btn-disabled" disabled><i class="fas fa-ban"></i> Full</button>` :
+                            `<button class="btn btn-sm" onclick="studentJoiner.joinSession('${session.id}')"><i class="fas fa-plus"></i> Join</button>`
                     }
                 </div>
             </div>
         `;
     }
 
-    joinSession(sessionId) {
-        const allStored = localStorage.getItem(this.storageKey);
-        if (!allStored) return;
-        const allSessions = JSON.parse(allStored);
+    initials(name) {
+        return String(name || '?').split(/\s+/).filter(Boolean).map(n => n[0]).join('').slice(0, 2).toUpperCase();
+    }
 
-        const session = allSessions.find(s => s.id === sessionId);
+    async joinSession(sessionId) {
+        const session = this.sessions.find(s => s.id === sessionId);
         if (!session) return;
 
-        if (!this.currentStudent || !this.currentStudent.fullName) {
+        if (!this.currentStudent || !this.getCurrentStudentLabel()) {
             alert('You must be logged in to join a session.');
             return;
         }
 
-        // Initialize joinedStudents if missing
-        if (!session.joinedStudents) session.joinedStudents = [];
-
-        if (session.joinedStudents.includes(this.currentStudent.fullName)) {
+        const currentIds = this.getCurrentStudentIds();
+        const joinedIds = session.joinedStudentIds || session.joinedStudents || [];
+        if (currentIds.some(id => joinedIds.includes(id))) {
             alert('You are already in this session.');
             return;
         }
 
-        session.joinedStudents.push(this.currentStudent.fullName);
+        const maxStudents = Number(session.maxStudents) || 1;
+        if (joinedIds.length >= maxStudents) {
+            alert('This session is already full.');
+            return;
+        }
+
+        if (session.source === 'api') {
+            await this.joinApiSession(session);
+            return;
+        }
+
+        this.joinLocalSession(sessionId);
+    }
+
+    async joinApiSession(session) {
+        const email = this.currentStudent.email || this.currentStudent.idNumber || this.getCurrentStudentLabel();
+        try {
+            const response = await fetch(`/api/bookings/${session.id}/join`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email })
+            });
+            const data = await response.json().catch(() => ({}));
+            if (!response.ok) {
+                alert(data.message || data.error || 'Failed to join session');
+                return;
+            }
+            await this.loadSessions();
+        } catch (error) {
+            console.error('Failed to join session:', error);
+            alert('Failed to join session');
+        }
+    }
+
+    joinLocalSession(sessionId) {
+        const allStored = localStorage.getItem(this.storageKey);
+        if (!allStored) return;
+        const allSessions = JSON.parse(allStored);
+        const session = allSessions.find(s => s.id === sessionId);
+        if (!session) return;
+
+        const studentLabel = this.getCurrentStudentLabel();
+        if (!session.joinedStudents) session.joinedStudents = [];
+        if (session.joinedStudents.includes(studentLabel)) {
+            alert('You are already in this session.');
+            return;
+        }
+        const maxStudents = Number(session.maxStudents) || Number(session.capacity) || 5;
+        if (session.joinedStudents.length >= maxStudents) {
+            alert('This session is already full.');
+            return;
+        }
+
+        session.joinedStudents.push(studentLabel);
         localStorage.setItem(this.storageKey, JSON.stringify(allSessions));
-        this.loadSessions();
+        this.loadLocalSessions();
         this.filterAndRender();
     }
 

--- a/public/lecturer-activity-log.html
+++ b/public/lecturer-activity-log.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Lecturer Activity Log</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="stylesheet" href="css/activity-log.css">
+</head>
+<body data-log-role="lecturer">
+    <div class="activity-container">
+        <header class="activity-header">
+            <div class="header-left">
+                <h1>
+                    <i class="fas fa-history"></i><span id="activity-log-title">Lecturer Activity Log</span>
+                </h1>
+                <p class="header-subtitle" id="activity-log-subtitle">Your availability and consultation activity</p>
+            </div>
+            <div class="header-right">
+                <button id="auto-refresh-toggle" class="btn btn-outline" title="Auto-refresh every 10 seconds">
+                    <i class="fas fa-sync-alt"></i>
+                    <span>Auto-refresh</span>
+                </button>
+            </div>
+        </header>
+
+        <div class="stats-bar">
+            <div class="stat-item">
+                <i class="fas fa-list"></i>
+                <span>Total Activities: <strong id="total-activities">0</strong></span>
+            </div>
+            <div class="stat-item">
+                <i class="fas fa-clock"></i>
+                <span>Today: <strong id="today-activities">0</strong></span>
+            </div>
+            <div class="stat-item">
+                <i class="fas fa-plus-circle"></i>
+                <span>Created: <strong id="created-count">0</strong></span>
+            </div>
+            <div class="stat-item">
+                <i class="fas fa-times-circle"></i>
+                <span>Canceled: <strong id="canceled-count">0</strong></span>
+            </div>
+            <div class="stat-item">
+                <i class="fas fa-user"></i>
+                <span>Users Active: <strong id="active-users">0</strong></span>
+            </div>
+        </div>
+
+        <div class="filters-section">
+            <div class="filter-row">
+                <div class="filter-group">
+                    <label for="action-type-filter"><i class="fas fa-tag"></i> Action Type</label>
+                    <select id="action-type-filter" class="filter-select">
+                        <option value="all">All Actions</option>
+                        <option value="created">Created</option>
+                        <option value="joined">Joined</option>
+                        <option value="updated">Updated</option>
+                        <option value="canceled">Canceled</option>
+                    </select>
+                </div>
+
+                <div class="filter-group">
+                    <label for="user-filter"><i class="fas fa-user"></i> User</label>
+                    <select id="user-filter" class="filter-select">
+                        <option value="all">All Relevant People</option>
+                    </select>
+                </div>
+
+                <div class="filter-group">
+                    <label for="date-range-filter"><i class="fas fa-calendar"></i> Date Range</label>
+                    <select id="date-range-filter" class="filter-select">
+                        <option value="all">All Time</option>
+                        <option value="today">Today</option>
+                        <option value="yesterday">Yesterday</option>
+                        <option value="last7">Last 7 Days</option>
+                        <option value="last30">Last 30 Days</option>
+                        <option value="custom">Custom Range</option>
+                    </select>
+                </div>
+
+                <div class="filter-group custom-date-range hidden" id="custom-date-range">
+                    <input type="date" id="start-date" class="date-input">
+                    <span>to</span>
+                    <input type="date" id="end-date" class="date-input">
+                    <button id="apply-date-range" class="btn btn-sm btn-primary">Apply</button>
+                </div>
+            </div>
+
+            <div class="filter-group">
+                <label for="course-filter"><i class="fas fa-book"></i> Course</label>
+                <select id="course-filter" class="filter-select">
+                    <option value="all">All Courses</option>
+                </select>
+            </div>
+
+            <div class="filter-row">
+                <div class="filter-group flex-grow">
+                    <label for="search-input"><i class="fas fa-search"></i> Search</label>
+                    <input type="text" id="search-input" class="search-input" placeholder="Search by course, venue, topic, student, or description...">
+                </div>
+
+                <div class="filter-actions">
+                    <button id="clear-filters-btn" class="btn btn-outline btn-sm"><i class="fas fa-times"></i> Clear Filters</button>
+                    <button id="export-activity-btn" class="btn btn-secondary btn-sm"><i class="fas fa-download"></i> Export CSV</button>
+                    <button id="bookmark-btn" class="btn btn-outline btn-sm" title="Copy shareable link"><i class="fas fa-bookmark"></i> Copy Link</button>
+                    <button id="clear-all-btn" class="btn btn-danger btn-sm"><i class="fas fa-trash"></i> Clear My Logs</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="activity-timeline-container">
+            <div id="activity-timeline" class="activity-timeline"></div>
+            <div id="empty-state" class="empty-state hidden">
+                <i class="fas fa-clipboard-list"></i>
+                <h3>No Lecturer Activity Recorded</h3>
+                <p id="empty-state-message">Availability changes and consultation bookings involving you will appear here.</p>
+            </div>
+            <div id="loading-indicator" class="loading-indicator hidden">
+                <i class="fas fa-spinner fa-spin"></i>
+                <span>Loading activities...</span>
+            </div>
+        </div>
+
+        <div class="pagination" id="pagination">
+            <button id="prev-page" class="btn btn-outline btn-sm" disabled><i class="fas fa-chevron-left"></i> Previous</button>
+            <span class="page-info">Page <strong id="current-page">1</strong> of <strong id="total-pages">1</strong></span>
+            <button id="next-page" class="btn btn-outline btn-sm" disabled>Next <i class="fas fa-chevron-right"></i></button>
+        </div>
+    </div>
+
+    <div id="detail-modal" class="modal hidden">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2>Activity Details</h2>
+                <button class="close-btn" id="close-detail-modal">&times;</button>
+            </div>
+            <div id="detail-content" class="detail-body"></div>
+        </div>
+    </div>
+
+    <script src="js/activity-log.js"></script>
+</body>
+</html>

--- a/public/lecturer-availability.html
+++ b/public/lecturer-availability.html
@@ -28,7 +28,7 @@
         </button>
         <div id="settings-dropdown" class="settings_dropdown hidden">
           <a href="/profile-page.html" class="dropdown_item">Profile</a>
-          <a href="/activity-log.html" class="dropdown_item">Activity Log</a>
+          <a href="/lecturer-activity-log.html" class="dropdown_item">Activity Log</a>
           <div class="dropdown_divider"></div>
           <a href="/login-page.html" class="dropdown_item logout_item">Logout</a>
         </div>

--- a/public/lecturer-dashboard.html
+++ b/public/lecturer-dashboard.html
@@ -31,7 +31,7 @@
                 </button>
                 <div id="settings-dropdown" class="settings_dropdown hidden">
             <a href="/profile-page.html" class="dropdown_item">Profile</a>
-            <a href="/activity-log.html" class="dropdown_item">Activity Log</a>
+            <a href="/lecturer-activity-log.html" class="dropdown_item">Activity Log</a>
             <a href="/logout" class="dropdown_item">Logout</a>
         </div>
             </div>

--- a/public/student-activity-log.html
+++ b/public/student-activity-log.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Student Activity Log</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="stylesheet" href="css/activity-log.css">
+</head>
+<body data-log-role="student">
+    <div class="activity-container">
+        <header class="activity-header">
+            <div class="header-left">
+                <h1>
+                    <i class="fas fa-history"></i><span id="activity-log-title">Student Activity Log</span>
+                </h1>
+                <p class="header-subtitle" id="activity-log-subtitle">Your booking and consultation activity</p>
+            </div>
+            <div class="header-right">
+                <button id="auto-refresh-toggle" class="btn btn-outline" title="Auto-refresh every 10 seconds">
+                    <i class="fas fa-sync-alt"></i>
+                    <span>Auto-refresh</span>
+                </button>
+            </div>
+        </header>
+
+        <div class="stats-bar">
+            <div class="stat-item">
+                <i class="fas fa-list"></i>
+                <span>Total Activities: <strong id="total-activities">0</strong></span>
+            </div>
+            <div class="stat-item">
+                <i class="fas fa-clock"></i>
+                <span>Today: <strong id="today-activities">0</strong></span>
+            </div>
+            <div class="stat-item">
+                <i class="fas fa-plus-circle"></i>
+                <span>Created: <strong id="created-count">0</strong></span>
+            </div>
+            <div class="stat-item">
+                <i class="fas fa-times-circle"></i>
+                <span>Canceled: <strong id="canceled-count">0</strong></span>
+            </div>
+            <div class="stat-item">
+                <i class="fas fa-user"></i>
+                <span>Users Active: <strong id="active-users">0</strong></span>
+            </div>
+        </div>
+
+        <div class="filters-section">
+            <div class="filter-row">
+                <div class="filter-group">
+                    <label for="action-type-filter"><i class="fas fa-tag"></i> Action Type</label>
+                    <select id="action-type-filter" class="filter-select">
+                        <option value="all">All Actions</option>
+                        <option value="created">Created</option>
+                        <option value="joined">Joined</option>
+                        <option value="updated">Updated</option>
+                        <option value="canceled">Canceled</option>
+                    </select>
+                </div>
+
+                <div class="filter-group">
+                    <label for="user-filter"><i class="fas fa-user"></i> User</label>
+                    <select id="user-filter" class="filter-select">
+                        <option value="all">All Relevant People</option>
+                    </select>
+                </div>
+
+                <div class="filter-group">
+                    <label for="date-range-filter"><i class="fas fa-calendar"></i> Date Range</label>
+                    <select id="date-range-filter" class="filter-select">
+                        <option value="all">All Time</option>
+                        <option value="today">Today</option>
+                        <option value="yesterday">Yesterday</option>
+                        <option value="last7">Last 7 Days</option>
+                        <option value="last30">Last 30 Days</option>
+                        <option value="custom">Custom Range</option>
+                    </select>
+                </div>
+
+                <div class="filter-group custom-date-range hidden" id="custom-date-range">
+                    <input type="date" id="start-date" class="date-input">
+                    <span>to</span>
+                    <input type="date" id="end-date" class="date-input">
+                    <button id="apply-date-range" class="btn btn-sm btn-primary">Apply</button>
+                </div>
+            </div>
+
+            <div class="filter-group">
+                <label for="course-filter"><i class="fas fa-book"></i> Course</label>
+                <select id="course-filter" class="filter-select">
+                    <option value="all">All Courses</option>
+                </select>
+            </div>
+
+            <div class="filter-row">
+                <div class="filter-group flex-grow">
+                    <label for="search-input"><i class="fas fa-search"></i> Search</label>
+                    <input type="text" id="search-input" class="search-input" placeholder="Search by course, venue, topic, lecturer, or description...">
+                </div>
+
+                <div class="filter-actions">
+                    <button id="clear-filters-btn" class="btn btn-outline btn-sm"><i class="fas fa-times"></i> Clear Filters</button>
+                    <button id="export-activity-btn" class="btn btn-secondary btn-sm"><i class="fas fa-download"></i> Export CSV</button>
+                    <button id="bookmark-btn" class="btn btn-outline btn-sm" title="Copy shareable link"><i class="fas fa-bookmark"></i> Copy Link</button>
+                    <button id="clear-all-btn" class="btn btn-danger btn-sm"><i class="fas fa-trash"></i> Clear My Logs</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="activity-timeline-container">
+            <div id="activity-timeline" class="activity-timeline"></div>
+            <div id="empty-state" class="empty-state hidden">
+                <i class="fas fa-clipboard-list"></i>
+                <h3>No Student Activity Recorded</h3>
+                <p id="empty-state-message">Bookings and consultation changes involving you will appear here.</p>
+            </div>
+            <div id="loading-indicator" class="loading-indicator hidden">
+                <i class="fas fa-spinner fa-spin"></i>
+                <span>Loading activities...</span>
+            </div>
+        </div>
+
+        <div class="pagination" id="pagination">
+            <button id="prev-page" class="btn btn-outline btn-sm" disabled><i class="fas fa-chevron-left"></i> Previous</button>
+            <span class="page-info">Page <strong id="current-page">1</strong> of <strong id="total-pages">1</strong></span>
+            <button id="next-page" class="btn btn-outline btn-sm" disabled>Next <i class="fas fa-chevron-right"></i></button>
+        </div>
+    </div>
+
+    <div id="detail-modal" class="modal hidden">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2>Activity Details</h2>
+                <button class="close-btn" id="close-detail-modal">&times;</button>
+            </div>
+            <div id="detail-content" class="detail-body"></div>
+        </div>
+    </div>
+
+    <script src="js/activity-log.js"></script>
+</body>
+</html>

--- a/public/student-dashboard.html
+++ b/public/student-dashboard.html
@@ -23,7 +23,7 @@
                             <nav id="side-menu" class="burger-dropdown hidden">
                                 <div class="menu-items">
                                     <a href="profile-page.html"><i class="fas fa-user-cog"></i> Profile Settings</a>
-                                    <a href="activity-log.html"><i class="fas fa-list-ul"></i> Activity Log</a>
+                                    <a href="student-activity-log.html"><i class="fas fa-list-ul"></i> Activity Log</a>
                                     <hr>
                                     <a href="login-page.html" class="sign-out"><i class="fas fa-sign-out-alt"></i> Sign Out</a>
                                 </div>

--- a/src/models/activity.js
+++ b/src/models/activity.js
@@ -5,6 +5,8 @@ const activitySchema = new mongoose.Schema({
     description: String,
     user: String,
     userId: String,
+    userEmail: String,
+    userRole: String,
     metadata: Object,
     timestamp: { type: Date, default: Date.now }
 });

--- a/src/models/booking.js
+++ b/src/models/booking.js
@@ -38,6 +38,10 @@ const bookingSchema = new mongoose.Schema({
     default: '',
     trim: true
   },
+  maxStudents: {
+    type: Number,
+    default: 1
+  },
   createdAt: {
     type: Date,
     default: Date.now

--- a/src/routes/activities.js
+++ b/src/routes/activities.js
@@ -107,6 +107,42 @@ function activityMatchesRequester(activity, requester) {
     return requester.values.some(value => searchableValues.includes(String(value)));
 }
 
+function getActivityCourse(activity) {
+    const metadata = activity.metadata || {};
+    return metadata.course || metadata.module || null;
+}
+
+function getLecturerCourseSet(availabilities, bookings, requester) {
+    if (requester.role !== 'lecturer') return null;
+
+    const lecturerAvailabilities = availabilities.filter(availability =>
+        requester.values.includes(String(availability.lecturerEmail))
+    );
+    const lecturerBookings = bookings.filter(booking =>
+        requester.values.includes(String(booking.lecturerId))
+    );
+
+    const courses = [
+        ...lecturerAvailabilities.flatMap(availability => [
+        ...(Array.isArray(availability.courses) ? availability.courses : []),
+        ...(availability.weeklySchedule || []).flatMap(day =>
+            (day.slots || []).map(slot => slot.course)
+        )
+        ]),
+        ...lecturerBookings.map(booking => booking.module)
+    ];
+
+    const courseSet = new Set(courses.filter(Boolean).map(String));
+    return courseSet.size > 0 ? courseSet : null;
+}
+
+function activityMatchesLecturerCourses(activity, lecturerCourses) {
+    if (!lecturerCourses) return true;
+
+    const course = getActivityCourse(activity);
+    return !course || lecturerCourses.has(String(course));
+}
+
 function bookingToActivity(booking) {
     const participants = Array.isArray(booking.participantIDs) ? booking.participantIDs : [];
     const canceled = booking.status === 'canceled';
@@ -193,12 +229,14 @@ router.get('/', async (req, res) => {
             Availability.find().lean()
         ]);
 
+        const lecturerCourses = getLecturerCourseSet(availabilities, bookings, requester);
         const combinedActivities = [
             ...activities.map(activity => enrichActivityIdentity(toPlainActivity(activity))),
             ...bookings.map(bookingToActivity),
             ...availabilities.flatMap(availabilityToActivities)
         ]
             .filter(activity => activityMatchesRequester(activity, requester))
+            .filter(activity => activityMatchesLecturerCourses(activity, lecturerCourses))
             .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
             .slice(0, 500);
 

--- a/src/routes/activities.js
+++ b/src/routes/activities.js
@@ -1,12 +1,208 @@
 const express = require('express');
 const router = express.Router();
 const Activity = require('../models/activity');
+const Booking = require('../models/booking');
+const Availability = require('../models/Availability');
 
-// GET all activities
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+function toPlainActivity(activity) {
+    const value = typeof activity.toObject === 'function' ? activity.toObject() : activity;
+    return {
+        ...value,
+        id: String(value._id || value.id)
+    };
+}
+
+function uniqueValues(values) {
+    return [...new Set(values.filter(Boolean).map(String))];
+}
+
+function enrichActivityIdentity(activity) {
+    const metadata = activity.metadata || {};
+    const actorId = metadata.actorId || activity.userId || activity.userEmail;
+    const actorEmail = metadata.actorEmail || activity.userEmail || activity.userId;
+    const role = activity.userRole || metadata.userRole || '';
+    const studentId = metadata.studentId || metadata.studentEmail || (role === 'student' ? actorId : null);
+    const studentEmail = metadata.studentEmail || metadata.studentId || (role === 'student' ? actorEmail : null);
+    const lecturerId = metadata.lecturerId || metadata.lecturerEmail || (role === 'lecturer' ? actorId : null);
+    const lecturerEmail = metadata.lecturerEmail || metadata.lecturerId || (role === 'lecturer' ? actorEmail : null);
+
+    return {
+        ...activity,
+        userId: activity.userId || actorId || studentId || lecturerId || null,
+        userEmail: activity.userEmail || actorEmail || studentEmail || lecturerEmail || null,
+        userRole: role,
+        metadata: {
+            ...metadata,
+            userId: metadata.userId || activity.userId || actorId || null,
+            userEmail: metadata.userEmail || activity.userEmail || actorEmail || null,
+            userRole: metadata.userRole || role,
+            actorId: actorId || null,
+            actorEmail: actorEmail || null,
+            studentId: studentId || null,
+            studentEmail: studentEmail || null,
+            lecturerId: lecturerId || null,
+            lecturerEmail: lecturerEmail || null,
+            participantIDs: uniqueValues([
+                ...(Array.isArray(metadata.participantIDs) ? metadata.participantIDs : []),
+                studentId
+            ]),
+            participantEmails: uniqueValues([
+                ...(Array.isArray(metadata.participantEmails) ? metadata.participantEmails : []),
+                studentEmail
+            ]),
+            audienceIds: uniqueValues([
+                ...(Array.isArray(metadata.audienceIds) ? metadata.audienceIds : []),
+                actorId,
+                studentId,
+                lecturerId
+            ]),
+            audienceEmails: uniqueValues([
+                ...(Array.isArray(metadata.audienceEmails) ? metadata.audienceEmails : []),
+                actorEmail,
+                studentEmail,
+                lecturerEmail
+            ])
+        }
+    };
+}
+
+function getRequester(req) {
+    const values = [
+        req.headers['x-user-email'],
+        req.headers['x-user-id'],
+        req.query.userEmail,
+        req.query.userId,
+        req.session?.userEmail
+    ].filter(Boolean);
+
+    return {
+        values: [...new Set(values.map(String))],
+        role: req.headers['x-user-role'] || req.query.role || ''
+    };
+}
+
+function activityMatchesRequester(activity, requester) {
+    if (requester.values.length === 0) return false;
+
+    const metadata = activity.metadata || {};
+    const searchableValues = [
+        activity.userId,
+        activity.userEmail,
+        metadata.userId,
+        metadata.userEmail,
+        metadata.actorId,
+        metadata.actorEmail,
+        metadata.studentId,
+        metadata.studentEmail,
+        metadata.lecturerId,
+        metadata.lecturerEmail,
+        ...(Array.isArray(metadata.participantIDs) ? metadata.participantIDs : []),
+        ...(Array.isArray(metadata.participantEmails) ? metadata.participantEmails : []),
+        ...(Array.isArray(metadata.audienceIds) ? metadata.audienceIds : []),
+        ...(Array.isArray(metadata.audienceEmails) ? metadata.audienceEmails : [])
+    ].filter(Boolean).map(String);
+
+    return requester.values.some(value => searchableValues.includes(String(value)));
+}
+
+function bookingToActivity(booking) {
+    const participants = Array.isArray(booking.participantIDs) ? booking.participantIDs : [];
+    const canceled = booking.status === 'canceled';
+    const id = String(booking._id || `${booking.studentId}-${booking.lecturerId}-${booking.date}-${booking.startTime}`);
+
+    return enrichActivityIdentity({
+        id: `booking-${id}`,
+        type: canceled ? 'canceled' : 'created',
+        description: `${canceled ? 'Canceled' : 'Booked'} ${booking.module || 'consultation'} consultation`,
+        user: booking.studentId,
+        userId: booking.studentId,
+        userEmail: booking.studentId,
+        userRole: 'student',
+        timestamp: booking.createdAt || new Date(),
+        metadata: {
+            source: 'booking',
+            bookingId: id,
+            course: booking.module,
+            module: booking.module,
+            date: booking.date,
+            startTime: booking.startTime,
+            endTime: booking.endTime,
+            venue: booking.venue,
+            topic: booking.topic,
+            status: booking.status,
+            studentId: booking.studentId,
+            studentEmail: booking.studentId,
+            lecturerId: booking.lecturerId,
+            lecturerEmail: booking.lecturerId,
+            participantIDs: participants,
+            participantEmails: participants,
+            audienceIds: uniqueValues([booking.studentId, booking.lecturerId, ...participants]),
+            audienceEmails: uniqueValues([booking.studentId, booking.lecturerId, ...participants])
+        }
+    });
+}
+
+function availabilityToActivities(availability) {
+    return (availability.weeklySchedule || []).flatMap(daySchedule => {
+        return (daySchedule.slots || []).map(slot => {
+            const id = String(slot._id || `${availability.lecturerEmail}-${daySchedule.dayOfWeek}-${slot.start}`);
+            return enrichActivityIdentity({
+                id: `slot-${id}`,
+                type: 'created',
+                description: `Available for ${slot.course} consultations`,
+                user: availability.lecturerName || availability.lecturerEmail,
+                userId: availability.lecturerEmail,
+                userEmail: availability.lecturerEmail,
+                userRole: 'lecturer',
+                timestamp: availability.updatedAt || new Date(),
+                metadata: {
+                    source: 'availability',
+                    slotId: id,
+                    lecturerId: availability.lecturerEmail,
+                    lecturerEmail: availability.lecturerEmail,
+                    lecturerName: availability.lecturerName,
+                    dayOfWeek: daySchedule.dayOfWeek,
+                    day: DAY_NAMES[daySchedule.dayOfWeek] || String(daySchedule.dayOfWeek),
+                    course: slot.course,
+                    startTime: slot.start,
+                    endTime: slot.end,
+                    duration: slot.duration,
+                    venue: slot.venue,
+                    maxStudents: slot.maxStudents,
+                    audienceIds: [availability.lecturerEmail],
+                    audienceEmails: [availability.lecturerEmail]
+                }
+            });
+        });
+    });
+}
+
+// GET current user's relevant activities
 router.get('/', async (req, res) => {
     try {
-        const activities = await Activity.find().sort({ timestamp: -1 }).limit(500);
-        res.json(activities);
+        const requester = getRequester(req);
+        if (requester.values.length === 0) {
+            return res.json([]);
+        }
+
+        const [activities, bookings, availabilities] = await Promise.all([
+            Activity.find().sort({ timestamp: -1 }).limit(500),
+            Booking.find().sort({ createdAt: -1 }).limit(500).lean(),
+            Availability.find().lean()
+        ]);
+
+        const combinedActivities = [
+            ...activities.map(activity => enrichActivityIdentity(toPlainActivity(activity))),
+            ...bookings.map(bookingToActivity),
+            ...availabilities.flatMap(availabilityToActivities)
+        ]
+            .filter(activity => activityMatchesRequester(activity, requester))
+            .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
+            .slice(0, 500);
+
+        res.json(combinedActivities);
     } catch (error) {
         res.status(500).json({ error: 'Failed to fetch activities' });
     }
@@ -15,18 +211,42 @@ router.get('/', async (req, res) => {
 // POST new activity
 router.post('/', async (req, res) => {
     try {
-        const activity = await Activity.create(req.body);
+        const metadata = req.body.metadata || {};
+        const activityData = enrichActivityIdentity({
+            ...req.body,
+            userEmail: req.body.userEmail || req.headers['x-user-email'] || metadata.userEmail || metadata.actorEmail,
+            userRole: req.body.userRole || req.headers['x-user-role'] || metadata.userRole,
+            userId: req.body.userId || req.headers['x-user-id'] || metadata.userId || metadata.actorId,
+            metadata: {
+                ...metadata,
+                actorId: metadata.actorId || req.headers['x-user-id'] || req.body.userId,
+                actorEmail: metadata.actorEmail || req.headers['x-user-email'] || req.body.userEmail
+            }
+        });
+        const activity = await Activity.create(activityData);
         res.status(201).json(activity);
     } catch (error) {
         res.status(500).json({ error: 'Failed to log activity' });
     }
 });
 
-// DELETE all activities
+// DELETE current user's activity records
 router.delete('/', async (req, res) => {
     try {
-        await Activity.deleteMany({});
-        res.json({ message: 'All activities cleared' });
+        const requester = getRequester(req);
+        if (requester.values.length === 0) {
+            return res.json({ message: 'No signed-in user activity to clear' });
+        }
+
+        const activities = await Activity.find();
+        const activityIds = activities
+            .map(toPlainActivity)
+            .filter(activity => activityMatchesRequester(activity, requester))
+            .map(activity => activity._id)
+            .filter(Boolean);
+
+        await Activity.deleteMany({ _id: { $in: activityIds } });
+        res.json({ message: 'Your activities were cleared' });
     } catch (error) {
         res.status(500).json({ error: 'Failed to clear activities' });
     }

--- a/src/routes/availability.js
+++ b/src/routes/availability.js
@@ -7,6 +7,27 @@ const Activity = require('../models/activity')
 
 const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
 
+async function resolveLecturerName (lecturerEmail) {
+  if (process.env.NODE_ENV === 'test' && !User.findOne?._isMockFunction && User.db?.readyState === 0) {
+    return 'Unknown Lecturer'
+  }
+
+  const queryConditions = [
+    { email: lecturerEmail },
+    { idNumber: lecturerEmail },
+    { username: lecturerEmail }
+  ]
+
+  if (!isNaN(lecturerEmail)) {
+    queryConditions.push({ idNumber: Number(lecturerEmail) })
+  }
+
+  const userRecord = await User.findOne({ $or: queryConditions })
+  const firstName = userRecord?.name || userRecord?.firstName || ''
+  const lastName = userRecord?.surname || userRecord?.lastName || ''
+  return `${firstName} ${lastName}`.trim() || 'Unknown Lecturer'
+}
+
 async function logAvailabilityActivity (activity) {
   if (process.env.NODE_ENV === 'test') {
     return
@@ -54,11 +75,7 @@ router.get('/', async (req, res) => {
 
     if (!availability) {
       // Create empty availability for new user
-      const userRecord = await User.findOne({ email: lecturerEmail })
-
-      const fullName = userRecord
-        ? `${userRecord.name} ${userRecord.surname}`
-        : 'Unknown Lecturer'
+      const fullName = await resolveLecturerName(lecturerEmail)
 
       availability = new Availability({
         lecturerEmail,
@@ -128,21 +145,7 @@ router.post('/slot', async (req, res) => {
 
     // Fetch and append the lecturer's real name if the document is new or lacks a name
     if (!availability || !availability.lecturerName || availability.lecturerName === 'Unknown Lecturer') {
-      const queryConditions = [
-        { email: lecturerEmail },
-        { idNumber: lecturerEmail },
-        { username: lecturerEmail }
-      ]
-
-      if (!isNaN(lecturerEmail)) {
-        queryConditions.push({ idNumber: Number(lecturerEmail) })
-      }
-
-      const userRecord = await User.findOne({ $or: queryConditions })
-
-      const firstName = userRecord?.name || userRecord?.firstName || ''
-      const lastName = userRecord?.surname || userRecord?.lastName || ''
-      const fullName = `${firstName} ${lastName}`.trim() || 'Unknown Lecturer'
+      const fullName = await resolveLecturerName(lecturerEmail)
 
       if (!availability) {
         availability = new Availability({

--- a/src/routes/availability.js
+++ b/src/routes/availability.js
@@ -3,6 +3,43 @@ const router = express.Router()
 const Availability = require('../models/Availability')
 const Booking = require('../models/booking')
 const User = require('../models/User')
+const Activity = require('../models/activity')
+
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+
+async function logAvailabilityActivity (activity) {
+  if (process.env.NODE_ENV === 'test') {
+    return
+  }
+
+  try {
+    await Activity.create({
+      ...activity,
+      timestamp: activity.timestamp || new Date()
+    })
+  } catch (error) {
+    console.error('Failed to log availability activity:', error.message)
+  }
+}
+
+function slotMetadata (lecturerEmail, lecturerName, dayOfWeek, slot, extra = {}) {
+  return {
+    lecturerId: lecturerEmail,
+    lecturerEmail,
+    lecturerName,
+    audienceIds: [lecturerEmail],
+    audienceEmails: [lecturerEmail],
+    dayOfWeek,
+    day: DAY_NAMES[dayOfWeek] || String(dayOfWeek),
+    course: slot.course,
+    startTime: slot.start,
+    endTime: slot.end,
+    duration: slot.duration,
+    venue: slot.venue,
+    maxStudents: slot.maxStudents,
+    ...extra
+  }
+}
 
 // GET lecturer's availability with booking status per slot
 router.get('/', async (req, res) => {
@@ -153,6 +190,20 @@ router.post('/slot', async (req, res) => {
     availability.updatedAt = new Date()
 
     await availability.save()
+    const addedSlot = daySchedule.slots[daySchedule.slots.length - 1]
+    await logAvailabilityActivity({
+      type: 'created',
+      description: `Added ${addedSlot.course} availability slot`,
+      user: availability.lecturerName || lecturerEmail,
+      userId: lecturerEmail,
+      userEmail: lecturerEmail,
+      userRole: 'lecturer',
+      metadata: slotMetadata(lecturerEmail, availability.lecturerName, dayOfWeek, addedSlot, {
+        actorId: lecturerEmail,
+        actorEmail: lecturerEmail,
+        userRole: 'lecturer'
+      })
+    })
 
     res.json({ success: true, message: 'Slot added successfully', availability })
   } catch (error) {
@@ -196,6 +247,7 @@ router.delete('/slot', async (req, res) => {
       return res.status(404).json({ success: false, message: 'Slot not found' })
     }
 
+    const removedSlot = daySchedule.slots[slotIndex]
     daySchedule.slots.splice(slotIndex, 1)
     if (daySchedule.slots.length === 0) {
       availability.weeklySchedule = availability.weeklySchedule.filter(d => d.dayOfWeek !== dayOfWeek)
@@ -208,6 +260,19 @@ router.delete('/slot', async (req, res) => {
     availability.courses = courses
     availability.updatedAt = new Date()
     await availability.save()
+    await logAvailabilityActivity({
+      type: 'canceled',
+      description: `Removed ${removedSlot.course} availability slot`,
+      user: availability.lecturerName || lecturerEmail,
+      userId: lecturerEmail,
+      userEmail: lecturerEmail,
+      userRole: 'lecturer',
+      metadata: slotMetadata(lecturerEmail, availability.lecturerName, dayOfWeek, removedSlot, {
+        actorId: lecturerEmail,
+        actorEmail: lecturerEmail,
+        userRole: 'lecturer'
+      })
+    })
 
     res.json({ success: true, message: 'Slot cancelled successfully', availability })
   } catch (error) {
@@ -281,6 +346,19 @@ router.put('/slot/:slotId', async (req, res) => {
 
     availability.markModified('weeklySchedule')
     await availability.save()
+    await logAvailabilityActivity({
+      type: 'updated',
+      description: `Updated ${slot.course} availability slot`,
+      user: availability.lecturerName || lecturerEmail,
+      userId: lecturerEmail,
+      userEmail: lecturerEmail,
+      userRole: 'lecturer',
+      metadata: slotMetadata(lecturerEmail, availability.lecturerName, dayOfWeek, slot, {
+        actorId: lecturerEmail,
+        actorEmail: lecturerEmail,
+        userRole: 'lecturer'
+      })
+    })
 
     res.json({ success: true, message: 'Slot updated successfully', availability })
   } catch (error) {

--- a/src/routes/bookings.js
+++ b/src/routes/bookings.js
@@ -208,12 +208,9 @@ router.get('/', async (req, res) => {
     // FIX: Search by both email AND idNumber since lecturerId contains the staff numeric ID
     const lecturers = lecturerIdentifiers.length
       ? await User.find({
-        $or: [
-          { email: { $in: lecturerIdentifiers } },
-          { idNumber: { $in: lecturerIdentifiers } }
-        ],
+        email: { $in: lecturerIdentifiers },
         role: 'lecturer'
-      }, 'name surname email idNumber').lean()
+      }, 'name surname email').lean()
       : []
 
     // Map names to both their email and idNumber for a bulletproof fallback lookup
@@ -221,7 +218,6 @@ router.get('/', async (req, res) => {
     lecturers.forEach(lecturer => {
       const fullName = [lecturer.name, lecturer.surname].filter(Boolean).join(' ')
       if (lecturer.email) lecturersByIdentifier.set(lecturer.email, fullName)
-      if (lecturer.idNumber) lecturersByIdentifier.set(lecturer.idNumber, fullName)
     })
 
     // Dynamically override the status to 'canceled' on the user's side if they left

--- a/src/routes/bookings.js
+++ b/src/routes/bookings.js
@@ -4,6 +4,7 @@ const router = express.Router()
 const Availability = require('../models/Availability')
 const Booking = require('../models/booking')
 const User = require('../models/user')
+const Activity = require('../models/activity')
 
 // Import your awesome middleware
 const { validateLecturerHours } = require('../middleware/booking-validator')
@@ -20,6 +21,49 @@ function formatStudentDisplayName (student) {
   const idNumber = student.idNumber ? `-${student.idNumber}` : ''
   const displayName = `${initial}${resolvedSurname}${idNumber}`
   return displayName || student.email
+}
+
+async function logBookingActivity (activity) {
+  if (process.env.NODE_ENV === 'test') {
+    return
+  }
+
+  try {
+    await Activity.create({
+      ...activity,
+      timestamp: activity.timestamp || new Date()
+    })
+  } catch (error) {
+    console.error('Failed to log booking activity:', error.message)
+  }
+}
+
+function uniqueValues (values) {
+  return [...new Set(values.filter(Boolean).map(String))]
+}
+
+function bookingActivityMetadata (booking, extra = {}) {
+  const bookingObject = typeof booking.toObject === 'function' ? booking.toObject() : booking
+  const participants = Array.isArray(bookingObject.participantIDs) ? bookingObject.participantIDs : []
+
+  return {
+    course: bookingObject.module,
+    module: bookingObject.module,
+    date: bookingObject.date,
+    startTime: bookingObject.startTime,
+    endTime: bookingObject.endTime,
+    venue: bookingObject.venue,
+    topic: bookingObject.topic,
+    studentId: bookingObject.studentId,
+    studentEmail: bookingObject.studentId,
+    lecturerId: bookingObject.lecturerId,
+    lecturerEmail: bookingObject.lecturerId,
+    participantIDs: participants,
+    participantEmails: participants,
+    audienceIds: uniqueValues([bookingObject.studentId, bookingObject.lecturerId, ...participants]),
+    audienceEmails: uniqueValues([bookingObject.studentId, bookingObject.lecturerId, ...participants]),
+    ...extra
+  }
 }
 
 // GET: Fetch all available courses and lecturers for the booking form
@@ -92,6 +136,19 @@ async function createBooking (req, res) {
     })
 
     const savedBooking = await newBooking.save()
+    await logBookingActivity({
+      type: 'created',
+      description: `Booked ${savedBooking.module || 'consultation'} consultation`,
+      user: req.body.studentId,
+      userId: req.body.studentId,
+      userEmail: req.body.studentId,
+      userRole: 'student',
+      metadata: bookingActivityMetadata(savedBooking, {
+        actorId: req.body.studentId,
+        actorEmail: req.body.studentId,
+        userRole: 'student'
+      })
+    })
     res.status(201).json({ message: 'Booking successful!', booking: savedBooking })
   } catch (error) {
     console.error(error)
@@ -208,6 +265,19 @@ router.delete('/:id', async (req, res) => {
       }
 
       await Booking.findByIdAndUpdate(id, { status: 'canceled' })
+      await logBookingActivity({
+        type: 'canceled',
+        description: `Canceled ${booking.module || 'consultation'} booking`,
+        user: studentEmail,
+        userId: studentEmail,
+        userEmail: studentEmail,
+        userRole: 'student',
+        metadata: bookingActivityMetadata(booking, {
+          actorId: studentEmail,
+          actorEmail: studentEmail,
+          userRole: 'student'
+        })
+      })
       return res.status(200).json({ success: true, message: 'Booking successfully canceled' })
     }
 
@@ -226,6 +296,19 @@ router.delete('/:id', async (req, res) => {
         participantIDs: updatedParticipants,
         $addToSet: { leftParticipantIDs: studentEmail } // Optional: Keep track of who left
       })
+      await logBookingActivity({
+        type: 'canceled',
+        description: `Canceled ${booking.module || 'consultation'} booking`,
+        user: studentEmail,
+        userId: studentEmail,
+        userEmail: studentEmail,
+        userRole: 'student',
+        metadata: bookingActivityMetadata(booking, {
+          actorId: studentEmail,
+          actorEmail: studentEmail,
+          userRole: 'student'
+        })
+      })
       return res.status(200).json({ success: true, message: 'Booking successfully canceled (no students remaining).' })
     }
 
@@ -233,6 +316,19 @@ router.delete('/:id', async (req, res) => {
     await Booking.findByIdAndUpdate(id, {
       participantIDs: updatedParticipants,
       $addToSet: { leftParticipantIDs: studentEmail }
+    })
+    await logBookingActivity({
+      type: 'canceled',
+      description: `Left ${booking.module || 'consultation'} booking`,
+      user: studentEmail,
+      userId: studentEmail,
+      userEmail: studentEmail,
+      userRole: 'student',
+      metadata: bookingActivityMetadata(booking, {
+        actorId: studentEmail,
+        actorEmail: studentEmail,
+        userRole: 'student'
+      })
     })
 
     res.status(200).json({ success: true, message: 'You have left the booking. It remains active for other students.' })
@@ -263,6 +359,19 @@ router.put('/leave/:id', async (req, res) => {
         participantIDs: updatedParticipants,
         $addToSet: { leftParticipantIDs: email }
       })
+      await logBookingActivity({
+        type: 'canceled',
+        description: `Canceled ${booking.module || 'consultation'} session`,
+        user: email,
+        userId: email,
+        userEmail: email,
+        userRole: 'student',
+        metadata: bookingActivityMetadata(booking, {
+          actorId: email,
+          actorEmail: email,
+          userRole: 'student'
+        })
+      })
       return res.json({ success: true, message: 'Session canceled completely (no students remaining).' })
     }
 
@@ -270,6 +379,19 @@ router.put('/leave/:id', async (req, res) => {
     await Booking.findByIdAndUpdate(id, {
       participantIDs: updatedParticipants,
       $addToSet: { leftParticipantIDs: email }
+    })
+    await logBookingActivity({
+      type: 'canceled',
+      description: `Left ${booking.module || 'consultation'} session`,
+      user: email,
+      userId: email,
+      userEmail: email,
+      userRole: 'student',
+      metadata: bookingActivityMetadata(booking, {
+        actorId: email,
+        actorEmail: email,
+        userRole: 'student'
+      })
     })
 
     res.json({ success: true, message: 'Successfully left the session.' })

--- a/src/routes/bookings.js
+++ b/src/routes/bookings.js
@@ -66,6 +66,65 @@ function bookingActivityMetadata (booking, extra = {}) {
   }
 }
 
+function getBookingObject (booking) {
+  return typeof booking.toObject === 'function' ? booking.toObject() : booking
+}
+
+function getBookingDayOfWeek (booking) {
+  const date = new Date(`${booking.date}T00:00:00`)
+  return date.getDay()
+}
+
+function findMatchingSlot (availability, booking) {
+  if (!availability || !Array.isArray(availability.weeklySchedule)) return null
+
+  const bookingDayOfWeek = getBookingDayOfWeek(booking)
+  const daySchedule = availability.weeklySchedule.find(day => day.dayOfWeek === bookingDayOfWeek)
+  if (!daySchedule || !Array.isArray(daySchedule.slots)) return null
+
+  return daySchedule.slots.find(slot => {
+    const sameTime = slot.start === booking.startTime && slot.end === booking.endTime
+    const sameCourse = !booking.module || !slot.course || slot.course === booking.module
+    return sameTime && sameCourse
+  }) || null
+}
+
+async function getEffectiveMaxStudents (booking) {
+  const bookingObject = getBookingObject(booking)
+
+  const availability = await Availability.findOne({ lecturerEmail: bookingObject.lecturerId })
+  const matchingSlot = findMatchingSlot(availability, bookingObject)
+  const slotMaxStudents = Number(matchingSlot?.maxStudents)
+
+  if (slotMaxStudents > 0) {
+    return slotMaxStudents
+  }
+
+  return Number(bookingObject.maxStudents) || 1
+}
+
+async function enrichBookingsWithCapacity (bookings) {
+  const lecturerIds = [...new Set(bookings.map(booking => booking.lecturerId).filter(Boolean))]
+  const availabilities = await Promise.all(
+    lecturerIds.map(async lecturerId => [
+      lecturerId,
+      await Availability.findOne({ lecturerEmail: lecturerId })
+    ])
+  )
+  const availabilityByLecturer = new Map(availabilities)
+
+  return bookings.map(booking => {
+    const bookingObject = getBookingObject(booking)
+    const matchingSlot = findMatchingSlot(availabilityByLecturer.get(bookingObject.lecturerId), bookingObject)
+    const maxStudents = Number(matchingSlot?.maxStudents) || Number(bookingObject.maxStudents) || 1
+    return {
+      ...bookingObject,
+      maxStudents,
+      spacesLeft: Math.max(maxStudents - (bookingObject.participantIDs || []).length, 0)
+    }
+  })
+}
+
 // GET: Fetch all available courses and lecturers for the booking form
 router.get('/form-data', async (req, res) => {
   try {
@@ -130,6 +189,7 @@ async function createBooking (req, res) {
       module: req.body.module,
       venue: req.body.venue || '',
       topic: req.body.topic.trim(),
+      maxStudents: Number(req.body.maxStudents) || 1,
       status: 'upcoming',
       participantIDs: [req.body.studentId], // CRITICAL for your "leave" feature
       leftParticipantIDs: []
@@ -190,18 +250,29 @@ router.put('/session/cancel', async (req, res) => {
 // GET: Fetch ONLY the logged-in student's bookings (RESTORED GROUP LOGIC)
 router.get('/', async (req, res) => {
   try {
-    const { studentId } = req.query
+    const { studentId, status } = req.query
 
-    if (!studentId) {
+    if (!studentId && !status) {
       return res.status(400).json({ error: 'Student ID is required.' })
     }
 
-    const rawBookings = await Booking.find({
-      $or: [
+    const query = {}
+    if (status) {
+      query.status = { $in: status.split(',').map(s => s.trim()).filter(Boolean) }
+    }
+    if (studentId) {
+      query.$or = [
         { participantIDs: studentId },
         { leftParticipantIDs: studentId }
       ]
-    }).sort({ date: 1, startTime: 1 }).lean()
+    }
+
+    const rawBookings = await Booking.find(query).sort({ date: 1, startTime: 1 }).lean()
+
+    if (!studentId) {
+      const bookings = await enrichBookingsWithCapacity(rawBookings)
+      return res.json(bookings)
+    }
 
     const lecturerIdentifiers = [...new Set(rawBookings.map(b => b.lecturerId).filter(Boolean))]
 
@@ -331,6 +402,37 @@ router.delete('/:id', async (req, res) => {
   } catch (error) {
     console.error(error)
     res.status(500).json({ success: false, message: 'Server error' })
+  }
+})
+
+// JOIN: Add a student to a peer session if there is capacity
+router.put('/:id/join', async (req, res) => {
+  try {
+    const { email } = req.body
+    const booking = await Booking.findById(req.params.id)
+
+    if (!booking) {
+      return res.status(404).json({ success: false, message: 'Session not found' })
+    }
+
+    const participants = Array.isArray(booking.participantIDs) ? booking.participantIDs : []
+    if (participants.includes(email)) {
+      return res.status(400).json({ success: false, message: 'Already joined this session' })
+    }
+
+    const maxStudents = await getEffectiveMaxStudents(booking)
+    if (participants.length >= maxStudents) {
+      return res.status(400).json({ success: false, message: 'This session is already full' })
+    }
+
+    await Booking.findByIdAndUpdate(req.params.id, {
+      $addToSet: { participantIDs: email }
+    })
+
+    res.json({ success: true, message: 'Successfully joined the session.' })
+  } catch (error) {
+    console.error(error)
+    res.status(500).json({ success: false, error: 'Failed to join session' })
   }
 })
 

--- a/tests/integration/activity-integration.test.js
+++ b/tests/integration/activity-integration.test.js
@@ -1,0 +1,166 @@
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('../../src/models/activity', () => ({
+  find: jest.fn(),
+  create: jest.fn(),
+  deleteMany: jest.fn()
+}));
+
+jest.mock('../../src/models/booking', () => ({
+  find: jest.fn()
+}));
+
+jest.mock('../../src/models/Availability', () => ({
+  find: jest.fn()
+}));
+
+const Activity = require('../../src/models/activity');
+const Booking = require('../../src/models/booking');
+const Availability = require('../../src/models/Availability');
+const activitiesRouter = require('../../src/routes/activities');
+
+function mockActivityFind(activities) {
+  Activity.find.mockReturnValue({
+    sort: jest.fn().mockReturnValue({
+      limit: jest.fn().mockResolvedValue(activities)
+    })
+  });
+}
+
+function mockBookingFind(bookings) {
+  Booking.find.mockReturnValue({
+    sort: jest.fn().mockReturnValue({
+      limit: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue(bookings)
+      })
+    })
+  });
+}
+
+function mockAvailabilityFind(availabilities) {
+  Availability.find.mockReturnValue({
+    lean: jest.fn().mockResolvedValue(availabilities)
+  });
+}
+
+describe('Activity API', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    app.use('/api/activities', activitiesRouter);
+  });
+
+  it('limits lecturer activity courses to courses they lecture', async () => {
+    mockActivityFind([
+      {
+        _id: 'activity-1',
+        type: 'created',
+        description: 'Booked ELEN4010 consultation',
+        user: 'student@wits.ac.za',
+        userId: 'student@wits.ac.za',
+        userEmail: 'student@wits.ac.za',
+        userRole: 'student',
+        timestamp: '2026-05-16T08:00:00.000Z',
+        metadata: {
+          course: 'ELEN4010',
+          lecturerId: 'lecturer@wits.ac.za',
+          lecturerEmail: 'lecturer@wits.ac.za',
+          audienceIds: ['lecturer@wits.ac.za'],
+          audienceEmails: ['lecturer@wits.ac.za']
+        }
+      },
+      {
+        _id: 'activity-2',
+        type: 'created',
+        description: 'Booked COMS3009 consultation',
+        user: 'student@wits.ac.za',
+        userId: 'student@wits.ac.za',
+        userEmail: 'student@wits.ac.za',
+        userRole: 'student',
+        timestamp: '2026-05-16T09:00:00.000Z',
+        metadata: {
+          course: 'COMS3009',
+          lecturerId: 'lecturer@wits.ac.za',
+          lecturerEmail: 'lecturer@wits.ac.za',
+          audienceIds: ['lecturer@wits.ac.za'],
+          audienceEmails: ['lecturer@wits.ac.za']
+        }
+      }
+    ]);
+    mockBookingFind([]);
+    mockAvailabilityFind([
+      {
+        lecturerEmail: 'lecturer@wits.ac.za',
+        courses: ['ELEN4010'],
+        weeklySchedule: [
+          { dayOfWeek: 1, slots: [{ course: 'ELEN4010', start: '10:00', end: '11:00' }] }
+        ]
+      }
+    ]);
+
+    const response = await request(app)
+      .get('/api/activities')
+      .set('X-User-Email', 'lecturer@wits.ac.za')
+      .set('X-User-Id', 'lecturer@wits.ac.za')
+      .set('X-User-Role', 'lecturer');
+
+    expect(response.status).toBe(200);
+    expect(response.body.map(activity => activity.metadata.course)).toEqual(['ELEN4010', 'ELEN4010']);
+    expect(response.body.map(activity => activity.metadata.course)).not.toContain('COMS3009');
+  });
+
+  it('keeps lecturer activity for modules they had past sessions for', async () => {
+    mockActivityFind([
+      {
+        _id: 'activity-1',
+        type: 'created',
+        description: 'Booked COMS3009 consultation',
+        user: 'student@wits.ac.za',
+        userId: 'student@wits.ac.za',
+        userEmail: 'student@wits.ac.za',
+        userRole: 'student',
+        timestamp: '2026-05-16T09:00:00.000Z',
+        metadata: {
+          course: 'COMS3009',
+          lecturerId: 'lecturer@wits.ac.za',
+          lecturerEmail: 'lecturer@wits.ac.za',
+          audienceIds: ['lecturer@wits.ac.za'],
+          audienceEmails: ['lecturer@wits.ac.za']
+        }
+      }
+    ]);
+    mockBookingFind([
+      {
+        _id: 'booking-1',
+        studentId: 'student@wits.ac.za',
+        lecturerId: 'lecturer@wits.ac.za',
+        module: 'COMS3009',
+        date: '2026-04-10',
+        startTime: '10:00',
+        endTime: '11:00',
+        status: 'completed',
+        participantIDs: ['student@wits.ac.za']
+      }
+    ]);
+    mockAvailabilityFind([
+      {
+        lecturerEmail: 'lecturer@wits.ac.za',
+        courses: ['ELEN4010'],
+        weeklySchedule: []
+      }
+    ]);
+
+    const response = await request(app)
+      .get('/api/activities')
+      .set('X-User-Email', 'lecturer@wits.ac.za')
+      .set('X-User-Id', 'lecturer@wits.ac.za')
+      .set('X-User-Role', 'lecturer');
+
+    expect(response.status).toBe(200);
+    expect(response.body.map(activity => activity.metadata.course)).toContain('COMS3009');
+  });
+});

--- a/tests/integration/availability-booking-integration.test.js
+++ b/tests/integration/availability-booking-integration.test.js
@@ -1,40 +1,90 @@
 const request = require('supertest')
 const express = require('express')
 const mongoose = require('mongoose')
-const { MongoMemoryServer } = require('mongodb-memory-server') // Optional but recommended for clean testing
 
-// Import your router and models
-const availabilityRouter = require('../src/routes/availability') // Adjust path to your route file
-const User = require('../src/models/user')
-const Availability = require('../src/models/Availability')
+const mockUsers = []
+const mockAvailabilityStore = []
+
+class MockAvailability {
+  constructor (data = {}) {
+    this.lecturerEmail = data.lecturerEmail
+    this.lecturerName = data.lecturerName
+    this.weeklySchedule = (data.weeklySchedule || []).map(day => ({
+      dayOfWeek: day.dayOfWeek,
+      slots: (day.slots || []).map(slot => ({
+        _id: slot._id || new mongoose.Types.ObjectId(),
+        start: slot.start,
+        end: slot.end,
+        duration: slot.duration,
+        course: slot.course,
+        venue: slot.venue,
+        maxStudents: slot.maxStudents
+      }))
+    }))
+    this.courses = [...(data.courses || [])]
+    this.updatedAt = data.updatedAt
+  }
+
+  static async findOne (query) {
+    return mockAvailabilityStore.find(item => item.lecturerEmail === query.lecturerEmail) || null
+  }
+
+  static async deleteMany () {
+    mockAvailabilityStore.length = 0
+  }
+
+  async save () {
+    const existingIndex = mockAvailabilityStore.findIndex(item => item.lecturerEmail === this.lecturerEmail)
+    if (existingIndex === -1) {
+      mockAvailabilityStore.push(this)
+    } else {
+      mockAvailabilityStore[existingIndex] = this
+    }
+    return this
+  }
+
+  markModified () {}
+}
+
+jest.mock('../../src/models/Availability', () => MockAvailability)
+jest.mock('../../src/models/booking', () => ({
+  find: jest.fn().mockResolvedValue([])
+}))
+jest.mock('../../src/models/activity', () => ({
+  create: jest.fn().mockResolvedValue({})
+}))
+jest.mock('../../src/models/User', () => ({
+  create: jest.fn(async user => {
+    mockUsers.push(user)
+    return user
+  }),
+  findOne: jest.fn(async query => {
+    const conditions = query.$or || [query]
+    return mockUsers.find(user => conditions.some(condition => {
+      return Object.entries(condition).every(([key, value]) => user[key] === value)
+    })) || null
+  }),
+  deleteMany: jest.fn(async () => {
+    mockUsers.length = 0
+  })
+}))
+
+const availabilityRouter = require('../../src/routes/availability')
+const User = require('../../src/models/User')
+const Availability = require('../../src/models/Availability')
 
 const app = express()
 app.use(express.json())
 app.use('/api/availability', availabilityRouter)
 
-let mongoServer
-
-// Setup an in-memory database before running tests so we don't mess up your real data
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create()
-  const uri = mongoServer.getUri()
-  await mongoose.connect(uri)
-})
-
-// Clear data between tests and close connection at the end
 afterEach(async () => {
   await User.deleteMany({})
   await Availability.deleteMany({})
-})
-
-afterAll(async () => {
-  await mongoose.disconnect()
-  await mongoServer.stop()
+  jest.clearAllMocks()
 })
 
 describe('POST /api/availability/slot - Lecturer Name Resolution', () => {
   it('should successfully find the lecturer name from the User collection using idNumber', async () => {
-    // 1. Seed a mock lecturer into our test database
     await User.create({
       idNumber: '2540701',
       name: 'Ofentse',
@@ -43,52 +93,41 @@ describe('POST /api/availability/slot - Lecturer Name Resolution', () => {
       role: 'lecturer'
     })
 
-    // 2. Prepare mock slot data payload
-    const newSlotData = {
-      dayOfWeek: 1,
-      start: '09:00',
-      end: '10:00',
-      duration: 60,
-      course: 'INF300',
-      venue: 'Lab 2',
-      maxStudents: 5
-    }
-
-    // 3. Send the POST request passing the ID in the headers
     const response = await request(app)
       .post('/api/availability/slot')
-      .set('x-lecturer-id', '2540701') // The header we debugged earlier
-      .send(newSlotData)
+      .set('x-lecturer-id', '2540701')
+      .send({
+        dayOfWeek: 1,
+        start: '09:00',
+        end: '10:00',
+        duration: 60,
+        course: 'INF300',
+        venue: 'Lab 2',
+        maxStudents: 5
+      })
 
-    // 4. Assertions (The checks)
     expect(response.status).toBe(200)
     expect(response.body.success).toBe(true)
-
-    // Check that the returned response object contains the correct name
     expect(response.body.availability.lecturerName).toBe('Ofentse Tembe')
 
-    // Check that it actually saved into the Availability database collection correctly
     const savedAvailability = await Availability.findOne({ lecturerEmail: '2540701' })
     expect(savedAvailability).toBeTruthy()
     expect(savedAvailability.lecturerName).toBe('Ofentse Tembe')
   })
 
   it('should fallback to "Unknown Lecturer" if the ID cannot be found in the database', async () => {
-    const newSlotData = {
-      dayOfWeek: 2,
-      start: '11:00',
-      end: '12:00',
-      duration: 60,
-      course: 'INF300',
-      venue: 'Room 4',
-      maxStudents: 10
-    }
-
-    // Send a request with an ID that doesn't exist in the database
     const response = await request(app)
       .post('/api/availability/slot')
       .set('x-lecturer-id', '9999999')
-      .send(newSlotData)
+      .send({
+        dayOfWeek: 2,
+        start: '11:00',
+        end: '12:00',
+        duration: 60,
+        course: 'INF300',
+        venue: 'Room 4',
+        maxStudents: 10
+      })
 
     expect(response.status).toBe(200)
     expect(response.body.availability.lecturerName).toBe('Unknown Lecturer')

--- a/tests/integration/booking-integration.test.js
+++ b/tests/integration/booking-integration.test.js
@@ -187,6 +187,100 @@ describe('Booking Integration Tests', () => {
     expect(Booking.find).not.toHaveBeenCalled();
   });
 
+  it('returns upcoming peer sessions when listing by status without a studentId', async () => {
+    const bookings = [
+      {
+        _id: 'b1',
+        studentId: 'owner@wits.ac.za',
+        lecturerId: 'lecturer@wits.ac.za',
+        participantIDs: ['owner@wits.ac.za'],
+        date: '2026-06-01',
+        startTime: '10:00',
+        endTime: '11:00',
+        module: 'ELEN50',
+        status: 'upcoming'
+      }
+    ];
+    const lean = jest.fn().mockResolvedValue(bookings);
+    const sort = jest.fn().mockReturnValue({ lean });
+    Booking.find.mockReturnValue({ sort });
+    Availability.findOne.mockResolvedValue({
+      weeklySchedule: [
+        {
+          dayOfWeek: 1,
+          slots: [
+            {
+              start: '10:00',
+              end: '11:00',
+              course: 'ELEN50',
+              maxStudents: 10
+            }
+          ]
+        }
+      ]
+    });
+
+    const response = await request(app)
+      .get('/api/bookings')
+      .query({ status: 'upcoming,ongoing' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([
+      {
+        ...bookings[0],
+        maxStudents: 10,
+        spacesLeft: 9
+      }
+    ]);
+    expect(Booking.find).toHaveBeenCalledWith({
+      status: { $in: ['upcoming', 'ongoing'] }
+    });
+    expect(sort).toHaveBeenCalledWith({ date: 1, startTime: 1 });
+    expect(lean).toHaveBeenCalled();
+    expect(Availability.findOne).toHaveBeenCalledWith({ lecturerEmail: 'lecturer@wits.ac.za' });
+    expect(User.find).not.toHaveBeenCalled();
+  });
+
+  it('allows students to join while the matching availability slot still has space', async () => {
+    const participantIDs = Array.from({ length: 9 }, (_, index) => `student${index}@wits.ac.za`);
+    Booking.findById.mockResolvedValue({
+      _id: 'booking-1',
+      lecturerId: 'lecturer@wits.ac.za',
+      date: '2026-06-01',
+      startTime: '10:00',
+      endTime: '11:00',
+      module: 'ELEN50',
+      maxStudents: 1,
+      participantIDs
+    });
+    Availability.findOne.mockResolvedValue({
+      weeklySchedule: [
+        {
+          dayOfWeek: 1,
+          slots: [
+            {
+              start: '10:00',
+              end: '11:00',
+              course: 'ELEN50',
+              maxStudents: 10
+            }
+          ]
+        }
+      ]
+    });
+    Booking.findByIdAndUpdate.mockResolvedValue({});
+
+    const response = await request(app)
+      .put('/api/bookings/booking-1/join')
+      .send({ email: 'newstudent@wits.ac.za' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(Booking.findByIdAndUpdate).toHaveBeenCalledWith('booking-1', {
+      $addToSet: { participantIDs: 'newstudent@wits.ac.za' }
+    });
+  });
+
   it('returns sorted bookings for the requested student', async () => {
     const bookings = [
       {

--- a/tests/unit/frontend-pages.test.js
+++ b/tests/unit/frontend-pages.test.js
@@ -282,6 +282,7 @@ describe('Booking page browser script', () => {
         startTime: '09:30',
         endTime: '10:00',
         venue: 'Room 101',
+        maxStudents: 5,
         participantIDs: ['student@wits.ac.za'],
         topic: 'Project planning'
       })

--- a/tests/unit/lecturer-dashboard.test.js
+++ b/tests/unit/lecturer-dashboard.test.js
@@ -340,6 +340,48 @@ describe('Lecturer Dashboard', () => {
     });
 
 
+    describe('Filtering and Sorting', () => {
+        test('should order ongoing sessions first then upcoming soonest', async () => {
+            const manager = new LecturerScheduleManager();
+            await waitForInit();
+
+            manager.sessions = [
+                {
+                    id: 'later',
+                    status: 'upcoming',
+                    date: '2026-05-20',
+                    time: '14:00',
+                    courseCode: 'ELEN4010',
+                    studentName: 'Later Student',
+                    joinedStudents: []
+                },
+                {
+                    id: 'soon',
+                    status: 'upcoming',
+                    date: '2026-05-18',
+                    time: '09:00',
+                    courseCode: 'ELEN4010',
+                    studentName: 'Soon Student',
+                    joinedStudents: []
+                },
+                {
+                    id: 'now',
+                    status: 'ongoing',
+                    date: '2026-05-18',
+                    time: '08:00',
+                    courseCode: 'ELEN4010',
+                    studentName: 'Now Student',
+                    joinedStudents: []
+                }
+            ];
+
+            manager.applyFilters();
+
+            expect(manager.filteredSessions.map(session => session.id)).toEqual(['now', 'soon', 'later']);
+        });
+    });
+
+
     describe('Rendering',() => {
         test('should show empty state when no sessions', () => {
             const manager = new LecturerScheduleManager();

--- a/tests/unit/student-dashboard.test.js
+++ b/tests/unit/student-dashboard.test.js
@@ -165,6 +165,18 @@ describe('StudentScheduleManager', () => {
       expect(manager.filteredSessions.length).toBe(1)
       expect(manager.filteredSessions[0].status).toBe('completed')
     })
+
+    test('applyFilters orders ongoing first then upcoming soonest', () => {
+      manager.sessions = [
+        { id: 'later', status: 'upcoming', date: '2026-05-20', time: '14:00', courseCode: 'CS101', topic: 'Later' },
+        { id: 'soon', status: 'upcoming', date: '2026-05-18', time: '09:00', courseCode: 'CS101', topic: 'Soon' },
+        { id: 'now', status: 'ongoing', date: '2026-05-18', time: '08:00', courseCode: 'CS101', topic: 'Now' }
+      ]
+
+      manager.applyFilters()
+
+      expect(manager.filteredSessions.map(session => session.id)).toEqual(['now', 'soon', 'later'])
+    })
   })
 
   describe('DOM Rendering & Actions', () => {

--- a/tests/unit/students-joining.test.js
+++ b/tests/unit/students-joining.test.js
@@ -29,6 +29,7 @@ beforeEach(() => {
     global.localStorage.clear();
     global.sessionStorage.clear();
     global.alert = jest.fn();
+    global.fetch = undefined;
 });
 
 const fs = require('fs');
@@ -54,29 +55,35 @@ afterAll(() => {
 });
 
 describe('Join Peer Session - Epic #4', () => {
+    const futureDate = () => new Date(Date.now() + 86400000).toISOString().split('T')[0];
+
     const testSessions = [
         {
             id: '1',
             courseCode: 'ELEN4010',
-            date: new Date().toISOString().split('T')[0],
+            date: futureDate(),
             time: '10:00',
+            endTime: '10:30',
             duration: 30,
             status: 'upcoming',
             studentName: 'Alice',
             topic: 'Arrays',
             joinedStudents: [],
+            maxStudents: 3,
             lecturerName: 'Dr. Smith'
         },
         {
             id: '2',
             courseCode: 'ELEN4006',
-            date: new Date().toISOString().split('T')[0],
+            date: futureDate(),
             time: '11:00',
+            endTime: '11:45',
             duration: 45,
             status: 'ongoing',
             studentName: 'Bob',
             topic: 'Sorting',
             joinedStudents: ['Bob'],
+            maxStudents: 2,
             lecturerName: 'Dr. Jones'
         }
     ];
@@ -112,5 +119,183 @@ describe('Join Peer Session - Epic #4', () => {
         joiner.filterAndRender(); // re-render
         const html = document.getElementById('sessions-list').innerHTML;
         expect(html).toContain('Joined');
+    });
+
+    test('should show remaining spaces for each session', () => {
+        new StudentSessionJoiner();
+        const text = document.getElementById('sessions-list').textContent;
+        expect(text).toContain('3 spaces left');
+        expect(text).toContain('1 space left');
+    });
+
+    test('should show configured courses even when no peer session is available yet', async () => {
+        global.fetch = jest.fn(url => {
+            if (url === '/api/bookings/form-data') {
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve([
+                        {
+                            courses: ['ELEN50'],
+                            weeklySchedule: [
+                                { slots: [{ course: 'COMS3009' }] }
+                            ]
+                        }
+                    ])
+                });
+            }
+
+            return Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve([])
+            });
+        });
+
+        new StudentSessionJoiner();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        const options = Array.from(document.getElementById('course-filter').options).map(option => option.value);
+        expect(options).toContain('ELEN50');
+        expect(options).toContain('COMS3009');
+    });
+
+    test('should render remaining space from API capacity', async () => {
+        global.fetch = jest.fn(url => {
+            if (url === '/api/bookings/form-data') {
+                return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+            }
+
+            return Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve([
+                    {
+                        _id: 'api-session',
+                        module: 'ELEN50',
+                        date: new Date(Date.now() + 86400000).toISOString().split('T')[0],
+                        startTime: '10:00',
+                        endTime: '11:00',
+                        status: 'upcoming',
+                        studentId: 'owner@uni.edu',
+                        participantIDs: Array.from({ length: 9 }, (_, index) => `student${index}@uni.edu`),
+                        maxStudents: 10,
+                        spacesLeft: 1
+                    }
+                ])
+            });
+        });
+
+        new StudentSessionJoiner();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        const text = document.getElementById('sessions-list').textContent;
+        expect(text).toContain('9/10 joined');
+        expect(text).toContain('1 space left');
+        expect(text).not.toContain('Full');
+    });
+
+    test('should order sessions happening soonest first', () => {
+        const soon = new Date(Date.now() + 86400000);
+        const later = new Date(Date.now() + 172800000);
+
+        global.localStorage.setItem('sychro_consultations', JSON.stringify([
+            {
+                id: 'later',
+                courseCode: 'ELEN4010',
+                date: later.toISOString().split('T')[0],
+                time: '12:00',
+                endTime: '13:00',
+                status: 'upcoming',
+                studentName: 'Later Student',
+                topic: 'Later topic',
+                joinedStudents: [],
+                maxStudents: 3
+            },
+            {
+                id: 'soon',
+                courseCode: 'ELEN4010',
+                date: soon.toISOString().split('T')[0],
+                time: '09:00',
+                endTime: '10:00',
+                status: 'upcoming',
+                studentName: 'Soon Student',
+                topic: 'Soon topic',
+                joinedStudents: [],
+                maxStudents: 3
+            }
+        ]));
+
+        new StudentSessionJoiner();
+        const cards = Array.from(document.querySelectorAll('.session-card'));
+        expect(cards[0].textContent).toContain('Soon topic');
+        expect(cards[1].textContent).toContain('Later topic');
+    });
+
+    test('should not display full sessions', () => {
+        global.localStorage.setItem('sychro_consultations', JSON.stringify([
+            {
+                id: 'full',
+                courseCode: 'ELEN4010',
+                date: new Date(Date.now() + 86400000).toISOString().split('T')[0],
+                time: '10:00',
+                endTime: '11:00',
+                status: 'upcoming',
+                studentName: 'Full Student',
+                topic: 'Full topic',
+                joinedStudents: ['A', 'B'],
+                maxStudents: 2
+            },
+            {
+                id: 'open',
+                courseCode: 'ELEN4010',
+                date: new Date(Date.now() + 86400000).toISOString().split('T')[0],
+                time: '12:00',
+                endTime: '13:00',
+                status: 'upcoming',
+                studentName: 'Open Student',
+                topic: 'Open topic',
+                joinedStudents: ['A'],
+                maxStudents: 2
+            }
+        ]));
+
+        new StudentSessionJoiner();
+        const text = document.getElementById('sessions-list').textContent;
+        expect(text).not.toContain('Full topic');
+        expect(text).toContain('Open topic');
+    });
+
+    test('should not display sessions after their meeting time has passed', () => {
+        const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+        const tomorrow = new Date(Date.now() + 86400000).toISOString().split('T')[0];
+        global.localStorage.setItem('sychro_consultations', JSON.stringify([
+            {
+                id: 'past',
+                courseCode: 'ELEN4010',
+                date: yesterday,
+                time: '10:00',
+                endTime: '11:00',
+                status: 'upcoming',
+                studentName: 'Past Student',
+                topic: 'Past topic',
+                joinedStudents: [],
+                maxStudents: 2
+            },
+            {
+                id: 'future',
+                courseCode: 'ELEN4010',
+                date: tomorrow,
+                time: '10:00',
+                endTime: '11:00',
+                status: 'upcoming',
+                studentName: 'Future Student',
+                topic: 'Future topic',
+                joinedStudents: [],
+                maxStudents: 2
+            }
+        ]));
+
+        new StudentSessionJoiner();
+        const text = document.getElementById('sessions-list').textContent;
+        expect(text).not.toContain('Past topic');
+        expect(text).toContain('Future topic');
     });
 });


### PR DESCRIPTION
## Summary

- Added separate activity log pages for students and lecturers.
- Redirected the old `/activity-log.html` page based on the signed-in user role.
- Scoped activity log results so users only see records linked to themselves.
- Added identity metadata for students and lecturers on activity records.
- Generated activity log entries from existing bookings and availability records.
- Added database logging for booking and availability changes.
- Improved peer session joining by showing remaining spaces correctly and hiding full or expired sessions.
- Ordered peer sessions, student dashboard sessions, and lecturer dashboard sessions by ongoing first, then soonest upcoming.
- Updated activity logs so lecturers only see relevant course activity, including courses they currently lecture and modules from past sessions.
- Removed the Details button from student dashboard session cards.

## Notes

- Activity records now include student/lecturer identifiers so logs can be linked to the correct signed-in user.