### PR TITLE
Fix:students joining

### DIFF
--- a/public/js/students-joining.js
+++ b/public/js/students-joining.js
@@ -12,6 +12,7 @@ class StudentSessionJoiner {
     async init() {
         this.loadCurrentStudent();
         await this.loadSessions();
+        this.updateFilterOptions();
         this.setupEventListeners();
         this.updateFilterOptions();
         this.render();
@@ -59,6 +60,7 @@ class StudentSessionJoiner {
     }
 
     filterAndRender() {
+        if (!Array.isArray(this.sessions)) return;
         const course = this.courseFilter.value;
         const searchTerm = this.searchInput.value.toLowerCase().trim();
 
@@ -75,7 +77,8 @@ class StudentSessionJoiner {
         this.render();
     }
 
-    updateFilterOptions() {
+        updateFilterOptions() {
+        if (!Array.isArray(this.sessions)) return;   // ← Add this line
         const courses = [...new Set(this.sessions.map(s => s.module).filter(Boolean))].sort();
         this.courseFilter.innerHTML = '<option value="all">All Courses</option>';
         courses.forEach(course => {

--- a/public/js/students-joining.js
+++ b/public/js/students-joining.js
@@ -9,9 +9,9 @@ class StudentSessionJoiner {
         this.init();
     }
 
-    init() {
+    async init() {
         this.loadCurrentStudent();
-        this.loadSessions();
+        await this.loadSessions();
         this.setupEventListeners();
         this.updateFilterOptions();
         this.render();
@@ -24,8 +24,8 @@ class StudentSessionJoiner {
     get searchInput() { return document.getElementById('search-input'); }
 
     setupEventListeners() {
-        document.getElementById('refresh-btn').addEventListener('click', () => {
-            this.loadSessions();
+        document.getElementById('refresh-btn').addEventListener('click', async () => {
+            await this.loadSessions();
             this.updateFilterOptions();
             this.render();
         });
@@ -44,11 +44,18 @@ class StudentSessionJoiner {
         }
     }
 
-    loadSessions() {
-        const stored = localStorage.getItem(this.storageKey);
-        const allSessions = stored ? JSON.parse(stored) : [];
-        // Show only upcoming/ongoing sessions, not canceled/completed
-        this.sessions = allSessions.filter(s => s.status === 'upcoming' || s.status === 'ongoing');
+    async loadSessions() {
+        try {
+            const response = await fetch('/api/bookings?status=upcoming,ongoing');
+            if (response.ok) {
+                this.sessions = await response.json();
+            } else {
+                this.sessions = [];
+            }
+        } catch (error) {
+            console.error('Failed to load sessions:', error);
+            this.sessions = [];
+        }
     }
 
     filterAndRender() {
@@ -56,9 +63,9 @@ class StudentSessionJoiner {
         const searchTerm = this.searchInput.value.toLowerCase().trim();
 
         this.filteredSessions = this.sessions.filter(session => {
-            if (course !== 'all' && session.courseCode !== course) return false;
+            if (course !== 'all' && session.module !== course) return false;
             if (searchTerm) {
-                const searchStr = `${session.studentName} ${session.topic} ${session.courseCode}`.toLowerCase();
+                const searchStr = `${session.studentName} ${session.topic} ${session.module}`.toLowerCase();
                 if (!searchStr.includes(searchTerm)) return false;
             }
             return true;
@@ -69,7 +76,7 @@ class StudentSessionJoiner {
     }
 
     updateFilterOptions() {
-        const courses = [...new Set(this.sessions.map(s => s.courseCode).filter(Boolean))].sort();
+        const courses = [...new Set(this.sessions.map(s => s.module).filter(Boolean))].sort();
         this.courseFilter.innerHTML = '<option value="all">All Courses</option>';
         courses.forEach(course => {
             const option = document.createElement('option');
@@ -90,28 +97,28 @@ class StudentSessionJoiner {
     }
 
     renderCard(session) {
-        const dateObj = new Date(`${session.date}T${session.time}`);
+        const dateObj = new Date(`${session.date}T${session.startTime}`);
         const dateDisplay = dateObj.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
         const timeDisplay = dateObj.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
-        const joinedStudents = session.joinedStudents || [];
+        const joinedStudents = session.participantIDs || [];
         const totalJoined = joinedStudents.length;
 
         // Check if current student already joined
-        const alreadyJoined = this.currentStudent && joinedStudents.includes(this.currentStudent.fullName);
+        const alreadyJoined = this.currentStudent && joinedStudents.includes(this.currentStudent.email);
 
         return `
             <div class="session-card">
                 <div class="session-time">
                     <div class="date">${dateDisplay}</div>
                     <div class="time">${timeDisplay}</div>
-                    <div style="font-size:12px;color:rgba(255,255,255,0.5)">${session.duration}min</div>
+                    <div style="font-size:12px;color:rgba(255,255,255,0.5)">${this.escape(session.module || 'No module')}</div>
                 </div>
                 <div class="session-info">
-                    <div class="session-course">${this.escape(session.courseCode)}</div>
+                    <div class="session-course">${this.escape(session.module || 'No module')}</div>
                     <div class="session-topic">${this.escape(session.topic || 'No topic')}</div>
                     <div class="session-owner">
-                        <i class="fas fa-user-circle"></i> Created by ${this.escape(session.studentName)}
-                        ${session.lecturerName ? ` with ${this.escape(session.lecturerName)}` : ''}
+                        <i class="fas fa-user-circle"></i> Created by ${this.escape(session.studentId)}
+                        ${session.lecturerId ? ` with ${this.escape(session.lecturerId)}` : ''}
                     </div>
                     <div class="attendees">
                         ${joinedStudents.slice(0, 4).map(name => 
@@ -124,38 +131,36 @@ class StudentSessionJoiner {
                 <div class="join-btn">
                     ${alreadyJoined ? 
                         `<button class="btn btn-success btn-sm" disabled><i class="fas fa-check"></i> Joined</button>` :
-                        `<button class="btn btn-sm" onclick="studentJoiner.joinSession('${session.id}')"><i class="fas fa-plus"></i> Join</button>`
+                        `<button class="btn btn-sm" onclick="studentJoiner.joinSession('${session._id}')"><i class="fas fa-plus"></i> Join</button>`
                     }
                 </div>
             </div>
         `;
     }
 
-    joinSession(sessionId) {
-        const allStored = localStorage.getItem(this.storageKey);
-        if (!allStored) return;
-        const allSessions = JSON.parse(allStored);
-
-        const session = allSessions.find(s => s.id === sessionId);
-        if (!session) return;
-
-        if (!this.currentStudent || !this.currentStudent.fullName) {
+    async joinSession(sessionId) {
+        if (!this.currentStudent || !this.currentStudent.email) {
             alert('You must be logged in to join a session.');
             return;
         }
 
-        // Initialize joinedStudents if missing
-        if (!session.joinedStudents) session.joinedStudents = [];
+        try {
+            const response = await fetch(`/api/bookings/${sessionId}/join`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email: this.currentStudent.email })
+            });
 
-        if (session.joinedStudents.includes(this.currentStudent.fullName)) {
-            alert('You are already in this session.');
-            return;
+            if (response.ok) {
+                await this.loadSessions();
+                this.filterAndRender();
+            } else {
+                const data = await response.json();
+                alert(data.error || 'Failed to join session');
+            }
+        } catch (error) {
+            console.error('Failed to join session:', error);
         }
-
-        session.joinedStudents.push(this.currentStudent.fullName);
-        localStorage.setItem(this.storageKey, JSON.stringify(allSessions));
-        this.loadSessions();
-        this.filterAndRender();
     }
 
     escape(str) {

--- a/src/routes/bookings.js
+++ b/src/routes/bookings.js
@@ -129,8 +129,7 @@ router.put('/session/cancel', async (req, res) => {
   }
 })
 
-// GET: Fetch ONLY the logged-in student's bookings (RESTORED GROUP LOGIC)
-// GET: Fetch ONLY the logged-in student's bookings (RESTORED GROUP LOGIC)
+// GET: Fetch ONLY the logged-in student's bookings 
 router.get('/', async (req, res) => {
     try {
         const { studentId, status } = req.query;
@@ -150,71 +149,47 @@ router.get('/', async (req, res) => {
 
         const bookings = await Booking.find(query).sort({ date: 1, startTime: 1 }).lean();
 
-        if (studentId) {
-            const mapped = bookings.map(b => {
-                if (b.leftParticipantIDs && b.leftParticipantIDs.includes(studentId)) {
-                    return { ...b, status: 'canceled' };
-                }
-                return b;
-            });
-            return res.json(mapped);
+        if (!studentId) {
+            return res.json(bookings);
         }
 
-        res.json(bookings);
+        const lecturerIdentifiers = [...new Set(bookings.map(b => b.lecturerId).filter(Boolean))];
+
+        const lecturers = lecturerIdentifiers.length
+            ? await User.find({
+                $or: [
+                    { email: { $in: lecturerIdentifiers } },
+                    { idNumber: { $in: lecturerIdentifiers } }
+                ],
+                role: 'lecturer'
+            }, 'name surname email idNumber').lean()
+            : [];
+
+        const lecturersByIdentifier = new Map();
+        lecturers.forEach(lecturer => {
+            const fullName = [lecturer.name, lecturer.surname].filter(Boolean).join(' ');
+            if (lecturer.email) lecturersByIdentifier.set(lecturer.email, fullName);
+            if (lecturer.idNumber) lecturersByIdentifier.set(lecturer.idNumber, fullName);
+        });
+
+        const mapped = bookings.map(b => {
+            const booking = {
+                ...b,
+                lecturerName: lecturersByIdentifier.get(b.lecturerId) || b.lecturerId || 'Unknown Lecturer'
+            };
+
+            if (b.leftParticipantIDs && b.leftParticipantIDs.includes(studentId)) {
+                return { ...booking, status: 'canceled' };
+            }
+            return booking;
+        });
+
+        res.json(mapped);
     } catch (error) {
         console.error(error);
         res.status(500).json({ error: 'Failed to fetch bookings' });
     }
-});
-
-    const rawBookings = await Booking.find({
-      $or: [
-        { participantIDs: studentId },
-        { leftParticipantIDs: studentId }
-      ]
-    }).sort({ date: 1, startTime: 1 }).lean()
-
-    const lecturerIdentifiers = [...new Set(rawBookings.map(b => b.lecturerId).filter(Boolean))]
-
-    // FIX: Search by both email AND idNumber since lecturerId contains the staff numeric ID
-    const lecturers = lecturerIdentifiers.length
-      ? await User.find({
-        $or: [
-          { email: { $in: lecturerIdentifiers } },
-          { idNumber: { $in: lecturerIdentifiers } }
-        ],
-        role: 'lecturer'
-      }, 'name surname email idNumber').lean()
-      : []
-
-    // Map names to both their email and idNumber for a bulletproof fallback lookup
-    const lecturersByIdentifier = new Map()
-    lecturers.forEach(lecturer => {
-      const fullName = [lecturer.name, lecturer.surname].filter(Boolean).join(' ')
-      if (lecturer.email) lecturersByIdentifier.set(lecturer.email, fullName)
-      if (lecturer.idNumber) lecturersByIdentifier.set(lecturer.idNumber, fullName)
-    })
-
-    // Dynamically override the status to 'canceled' on the user's side if they left
-    const bookings = rawBookings.map(b => {
-      const booking = {
-        ...b,
-        // FIX: Grab the mapped name using the identifier map
-        lecturerName: lecturersByIdentifier.get(b.lecturerId) || b.lecturerId || 'Unknown Lecturer'
-      }
-
-      if (b.leftParticipantIDs && b.leftParticipantIDs.includes(studentId)) {
-        return { ...booking, status: 'canceled' }
-      }
-      return booking
-    })
-
-    res.json(bookings)
-  } catch (error) {
-    console.error(error)
-    res.status(500).json({ error: 'Failed to fetch bookings' })
-  }
-})
+}); 
 
 // DELETE: Cancel a booking (Now handles smart cancellation)
 router.delete('/:id', async (req, res) => {

--- a/src/routes/bookings.js
+++ b/src/routes/bookings.js
@@ -82,35 +82,40 @@ router.post('/', validateLecturerHours, async (req, res) => {
 
 // GET: Fetch ONLY the logged-in student's bookings (RESTORED GROUP LOGIC)
 router.get('/', async (req, res) => {
-  try {
-    const { studentId } = req.query
+    try {
+        const { studentId, status } = req.query;
+        const query = {};
 
-    if (!studentId) {
-      return res.status(400).json({ error: 'Student ID is required.' })
+        if (status) {
+            const statuses = status.split(',');
+            query.status = { $in: statuses };
+        }
+
+        if (studentId) {
+            query.$or = [
+                { participantIDs: studentId },
+                { leftParticipantIDs: studentId }
+            ];
+        }
+
+        const bookings = await Booking.find(query).sort({ date: 1, startTime: 1 }).lean();
+
+        if (studentId) {
+            const mapped = bookings.map(b => {
+                if (b.leftParticipantIDs && b.leftParticipantIDs.includes(studentId)) {
+                    return { ...b, status: 'canceled' };
+                }
+                return b;
+            });
+            return res.json(mapped);
+        }
+
+        res.json(bookings);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ error: 'Failed to fetch bookings' });
     }
-
-    // Fetch bookings where the student is currently active OR where they previously left
-    const rawBookings = await Booking.find({
-      $or: [
-        { participantIDs: studentId },
-        { leftParticipantIDs: studentId }
-      ]
-    }).sort({ date: 1, startTime: 1 }).lean()
-
-    // Dynamically override the status to 'canceled' on the user's side if they left
-    const bookings = rawBookings.map(b => {
-      if (b.leftParticipantIDs && b.leftParticipantIDs.includes(studentId)) {
-        return { ...b, status: 'canceled' }
-      }
-      return b
-    })
-
-    res.json(bookings)
-  } catch (error) {
-    console.error(error)
-    res.status(500).json({ error: 'Failed to fetch bookings' })
-  }
-})
+});
 
 // DELETE: Cancel a booking (ORGANIZER ONLY)
 router.delete('/:id', async (req, res) => {
@@ -141,28 +146,30 @@ router.delete('/:id', async (req, res) => {
   }
 })
 
-// LEAVE: Leave a booking (Joiners only)
-router.put('/leave/:id', async (req, res) => {
-  try {
-    const { email } = req.body
-    const booking = await Booking.findById(req.params.id)
+// PUT: Join a session (add student to participantIDs)
+router.put('/:id/join', async (req, res) => {
+    try {
+        const { email } = req.body;
+        const booking = await Booking.findById(req.params.id);
 
-    if (!booking) {
-      return res.status(404).json({ success: false, message: 'Booking not found' })
+        if (!booking) {
+            return res.status(404).json({ success: false, message: 'Session not found' });
+        }
+
+        if (booking.participantIDs.includes(email)) {
+            return res.status(400).json({ success: false, message: 'Already joined this session' });
+        }
+
+        await Booking.findByIdAndUpdate(req.params.id, {
+            $addToSet: { participantIDs: email }
+        });
+
+        res.json({ success: true, message: 'Successfully joined the session.' });
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ success: false, error: 'Failed to join session' });
     }
-
-    // Reduces participant count by pulling from participantIDs, and records the leave
-    await Booking.findByIdAndUpdate(req.params.id, {
-      $pull: { participantIDs: email },
-      $addToSet: { leftParticipantIDs: email }
-    })
-
-    res.json({ success: true, message: 'Successfully left the session.' })
-  } catch (error) {
-    console.error(error)
-    res.status(500).json({ success: false, error: 'Failed to leave session' })
-  }
-})
+});
 
 // LEAVE: Leave a booking (Joiners only)
 router.put('/leave/:id', async (req, res) => {

--- a/src/routes/bookings.js
+++ b/src/routes/bookings.js
@@ -250,13 +250,6 @@ router.put('/:id/join', async (req, res) => {
     try {
         const { email } = req.body;
         const booking = await Booking.findById(req.params.id);
-// LEAVE: Leave a booking (Using the exact same smart logic for consistency)
-router.put('/leave/:id', async (req, res) => {
-  try {
-    const { id } = req.params
-    const { email } = req.body
-
-    const booking = await Booking.findById(id)
 
         if (!booking) {
             return res.status(404).json({ success: false, message: 'Session not found' });
@@ -379,6 +372,7 @@ router.put('/:id', async (req, res) => {
     console.error(error)
     res.status(500).json({ error: 'Failed to update booking' })
   }
-})
+});
 
-module.exports = router
+
+module.exports = router  

--- a/src/routes/bookings.js
+++ b/src/routes/bookings.js
@@ -3,30 +3,14 @@ const express = require('express')
 const router = express.Router()
 const Availability = require('../models/Availability')
 const Booking = require('../models/booking')
-const User = require('../models/user')
 
 // Import your awesome middleware
 const { validateLecturerHours } = require('../middleware/booking-validator')
 
-function formatStudentDisplayName (student) {
-  const firstName = student.name ? student.name.trim() : ''
-  const surname = student.surname ? student.surname.trim() : ''
-  const displayNameParts = (student.displayName || '').trim().split(/\s+/)
-  const displayFirstName = displayNameParts.length > 1 ? displayNameParts[0] : ''
-  const displaySurname = displayNameParts.length > 1 ? displayNameParts.slice(1).join(' ') : ''
-  const resolvedFirstName = firstName || displayFirstName
-  const resolvedSurname = surname || displaySurname
-  const initial = resolvedFirstName ? `${resolvedFirstName.charAt(0).toUpperCase()}.` : ''
-  const idNumber = student.idNumber ? `-${student.idNumber}` : ''
-  const displayName = `${initial}${resolvedSurname}${idNumber}`
-  return displayName || student.email
-}
-
 // GET: Fetch all available courses and lecturers for the booking form
 router.get('/form-data', async (req, res) => {
   try {
-    // ADDED 'lecturerName' TO THE SELECT LIST BELOW
-    const availabilities = await Availability.find({}, 'lecturerEmail lecturerName courses weeklySchedule')
+    const availabilities = await Availability.find({}, 'lecturerEmail courses weeklySchedule')
     res.json(availabilities)
   } catch (error) {
     console.error('Error fetching form data:', error)
@@ -41,7 +25,7 @@ router.get('/availability', async (req, res) => {
     const dateObj = new Date(date)
     const dayOfWeek = dateObj.getDay()
 
-    const schedule = await Availability.findOne({ lecturerEmail: lecturerId })
+    const schedule = await Availability.findOne({ lecturerId })
 
     if (!schedule) {
       return res.status(404).json({ error: 'Lecturer availability not found.' })
@@ -71,12 +55,10 @@ router.get('/availability', async (req, res) => {
   }
 })
 
-async function createBooking (req, res) {
+// POST: Save a new booking (MERGED AND FIXED!)
+// Notice how it uses your middleware AND saves the data properly now
+router.post('/', validateLecturerHours, async (req, res) => {
   try {
-    if (!req.body.topic || !req.body.topic.trim()) {
-      return res.status(400).json({ success: false, message: 'Topic is required' })
-    }
-
     const newBooking = new Booking({
       studentId: req.body.studentId,
       lecturerId: req.body.lecturerId,
@@ -84,8 +66,7 @@ async function createBooking (req, res) {
       startTime: req.body.startTime,
       endTime: req.body.endTime,
       module: req.body.module,
-      venue: req.body.venue || '',
-      topic: req.body.topic.trim(),
+      topic: req.body.topic,
       status: 'upcoming',
       participantIDs: [req.body.studentId], // CRITICAL for your "leave" feature
       leftParticipantIDs: []
@@ -97,39 +78,8 @@ async function createBooking (req, res) {
     console.error(error)
     res.status(500).json({ error: 'Failed to create booking' })
   }
-}
-
-// POST: Save a new booking (MERGED AND FIXED!)
-// Notice how it uses your middleware AND saves the data properly now
-router.post('/', validateLecturerHours, createBooking)
-router.post('/create', validateLecturerHours, createBooking)
-
-// PUT: Cancel every booking that belongs to the same grouped lecturer session
-router.put('/session/cancel', async (req, res) => {
-  try {
-    const { bookingIds } = req.body
-
-    if (!Array.isArray(bookingIds) || bookingIds.length === 0) {
-      return res.status(400).json({ success: false, message: 'bookingIds are required' })
-    }
-
-    const result = await Booking.updateMany(
-      { _id: { $in: bookingIds } },
-      { $set: { status: 'canceled' } }
-    )
-
-    res.json({
-      success: true,
-      message: 'Session canceled for all participants',
-      modifiedCount: result.modifiedCount || 0
-    })
-  } catch (error) {
-    console.error(error)
-    res.status(500).json({ success: false, message: 'Failed to cancel session' })
-  }
 })
 
-// GET: Fetch ONLY the logged-in student's bookings (RESTORED GROUP LOGIC)
 // GET: Fetch ONLY the logged-in student's bookings (RESTORED GROUP LOGIC)
 router.get('/', async (req, res) => {
     try {
@@ -167,62 +117,13 @@ router.get('/', async (req, res) => {
     }
 });
 
-    const rawBookings = await Booking.find({
-      $or: [
-        { participantIDs: studentId },
-        { leftParticipantIDs: studentId }
-      ]
-    }).sort({ date: 1, startTime: 1 }).lean()
-
-    const lecturerIdentifiers = [...new Set(rawBookings.map(b => b.lecturerId).filter(Boolean))]
-
-    // FIX: Search by both email AND idNumber since lecturerId contains the staff numeric ID
-    const lecturers = lecturerIdentifiers.length
-      ? await User.find({
-        $or: [
-          { email: { $in: lecturerIdentifiers } },
-          { idNumber: { $in: lecturerIdentifiers } }
-        ],
-        role: 'lecturer'
-      }, 'name surname email idNumber').lean()
-      : []
-
-    // Map names to both their email and idNumber for a bulletproof fallback lookup
-    const lecturersByIdentifier = new Map()
-    lecturers.forEach(lecturer => {
-      const fullName = [lecturer.name, lecturer.surname].filter(Boolean).join(' ')
-      if (lecturer.email) lecturersByIdentifier.set(lecturer.email, fullName)
-      if (lecturer.idNumber) lecturersByIdentifier.set(lecturer.idNumber, fullName)
-    })
-
-    // Dynamically override the status to 'canceled' on the user's side if they left
-    const bookings = rawBookings.map(b => {
-      const booking = {
-        ...b,
-        // FIX: Grab the mapped name using the identifier map
-        lecturerName: lecturersByIdentifier.get(b.lecturerId) || b.lecturerId || 'Unknown Lecturer'
-      }
-
-      if (b.leftParticipantIDs && b.leftParticipantIDs.includes(studentId)) {
-        return { ...booking, status: 'canceled' }
-      }
-      return booking
-    })
-
-    res.json(bookings)
-  } catch (error) {
-    console.error(error)
-    res.status(500).json({ error: 'Failed to fetch bookings' })
-  }
-})
-
-// DELETE: Cancel a booking (Now handles smart cancellation)
+// DELETE: Cancel a booking (ORGANIZER ONLY)
 router.delete('/:id', async (req, res) => {
   try {
     const { id } = req.params
-    const { studentEmail } = req.body
+    const { studentEmail } = req.body // The test sends { studentEmail: '...' }
 
-    // 1. Find the booking
+    // 1. Find the booking first
     const booking = await Booking.findById(id)
 
     // 2. If it doesn't exist, return 404
@@ -230,40 +131,15 @@ router.delete('/:id', async (req, res) => {
       return res.status(404).json({ success: false, message: 'Booking not found' })
     }
 
-    if (!Array.isArray(booking.participantIDs)) {
-      if (booking.studentId !== studentEmail) {
-        return res.status(403).json({ success: false, message: 'Unauthorized to cancel this booking' })
-      }
-
-      await Booking.findByIdAndUpdate(id, { status: 'canceled' })
-      return res.status(200).json({ success: true, message: 'Booking successfully canceled' })
-    }
-
-    if (!booking.participantIDs.includes(studentEmail)) {
+    // 3. If the person deleting it isn't the owner, return 403 Unauthorized
+    if (booking.studentId !== studentEmail) {
       return res.status(403).json({ success: false, message: 'Unauthorized to cancel this booking' })
     }
 
-    // 3. Remove this student from the participants array
-    const updatedParticipants = booking.participantIDs.filter(email => email !== studentEmail)
+    // 4. If it passes all checks, go ahead and cancel it!
+    await Booking.findByIdAndUpdate(id, { status: 'canceled' })
 
-    // 4. Check if the booking is now empty
-    if (updatedParticipants.length === 0) {
-      // No one left -> Cancel the booking completely
-      await Booking.findByIdAndUpdate(id, {
-        status: 'canceled',
-        participantIDs: updatedParticipants,
-        $addToSet: { leftParticipantIDs: studentEmail } // Optional: Keep track of who left
-      })
-      return res.status(200).json({ success: true, message: 'Booking successfully canceled (no students remaining).' })
-    }
-
-    // 5. Others are still in the booking -> Just remove this student, keep it active
-    await Booking.findByIdAndUpdate(id, {
-      participantIDs: updatedParticipants,
-      $addToSet: { leftParticipantIDs: studentEmail }
-    })
-
-    res.status(200).json({ success: true, message: 'You have left the booking. It remains active for other students.' })
+    res.status(200).json({ success: true, message: 'Booking successfully canceled' })
   } catch (error) {
     console.error(error)
     res.status(500).json({ success: false, message: 'Server error' })
@@ -275,13 +151,6 @@ router.put('/:id/join', async (req, res) => {
     try {
         const { email } = req.body;
         const booking = await Booking.findById(req.params.id);
-// LEAVE: Leave a booking (Using the exact same smart logic for consistency)
-router.put('/leave/:id', async (req, res) => {
-  try {
-    const { id } = req.params
-    const { email } = req.body
-
-    const booking = await Booking.findById(id)
 
         if (!booking) {
             return res.status(404).json({ success: false, message: 'Session not found' });
@@ -307,21 +176,13 @@ router.put('/leave/:id', async (req, res) => {
   try {
     const { email } = req.body
     const booking = await Booking.findById(req.params.id)
-    const updatedParticipants = booking.participantIDs.filter(p => p !== email)
 
-    // If the last joiner leaves, cancel the booking
-    if (updatedParticipants.length === 0) {
-      await Booking.findByIdAndUpdate(id, {
-        status: 'canceled',
-        participantIDs: updatedParticipants,
-        $addToSet: { leftParticipantIDs: email }
-      })
-      return res.json({ success: true, message: 'Session canceled completely (no students remaining).' })
+    if (!booking) {
+      return res.status(404).json({ success: false, message: 'Booking not found' })
     }
 
-    // Otherwise, just remove them
-    await Booking.findByIdAndUpdate(id, {
-      participantIDs: updatedParticipants,
+    await Booking.findByIdAndUpdate(req.params.id, {
+      $pull: { participantIDs: email },
       $addToSet: { leftParticipantIDs: email }
     })
 
@@ -337,42 +198,11 @@ router.get('/lecturer/bookings', async (req, res) => {
   try {
     const { email } = req.query
     const bookings = await Booking.find({
-      lecturerId: email
+      lecturerId: email,
+      status: 'upcoming'
     }).sort({ date: 1, startTime: 1 })
 
-    const studentIdentifiers = [...new Set(bookings.flatMap(booking => [
-      booking.studentId,
-      ...(Array.isArray(booking.participantIDs) ? booking.participantIDs : [])
-    ]).filter(Boolean))]
-
-    const students = studentIdentifiers.length
-      ? await User.find({
-        $or: [
-          { email: { $in: studentIdentifiers } },
-          { idNumber: { $in: studentIdentifiers } }
-        ]
-      }, 'name surname displayName idNumber email').lean()
-      : []
-    const studentsByIdentifier = new Map()
-    students.forEach(student => {
-      const displayName = formatStudentDisplayName(student)
-      if (student.email) studentsByIdentifier.set(student.email, displayName)
-      if (student.idNumber) studentsByIdentifier.set(student.idNumber, displayName)
-    })
-
-    const enrichedBookings = bookings.map(booking => {
-      const bookingObject = typeof booking.toObject === 'function' ? booking.toObject() : booking
-      const participantNames = (bookingObject.participantIDs || [])
-        .map(studentId => studentsByIdentifier.get(studentId) || studentId)
-
-      return {
-        ...bookingObject,
-        studentName: studentsByIdentifier.get(bookingObject.studentId) || bookingObject.studentId,
-        participantNames
-      }
-    })
-
-    res.json(enrichedBookings)
+    res.json(bookings)
   } catch (err) {
     res.status(500).json({ message: err.message })
   }

--- a/src/routes/bookings.js
+++ b/src/routes/bookings.js
@@ -250,6 +250,13 @@ router.put('/:id/join', async (req, res) => {
     try {
         const { email } = req.body;
         const booking = await Booking.findById(req.params.id);
+// LEAVE: Leave a booking (Using the exact same smart logic for consistency)
+router.put('/leave/:id', async (req, res) => {
+  try {
+    const { id } = req.params
+    const { email } = req.body
+
+    const booking = await Booking.findById(id)
 
         if (!booking) {
             return res.status(404).json({ success: false, message: 'Session not found' });
@@ -372,7 +379,6 @@ router.put('/:id', async (req, res) => {
     console.error(error)
     res.status(500).json({ error: 'Failed to update booking' })
   }
-});
+})
 
-
-module.exports = router  
+module.exports = router

--- a/src/routes/bookings.js
+++ b/src/routes/bookings.js
@@ -129,7 +129,8 @@ router.put('/session/cancel', async (req, res) => {
   }
 })
 
-// GET: Fetch ONLY the logged-in student's bookings 
+// GET: Fetch ONLY the logged-in student's bookings (RESTORED GROUP LOGIC)
+// GET: Fetch ONLY the logged-in student's bookings (RESTORED GROUP LOGIC)
 router.get('/', async (req, res) => {
     try {
         const { studentId, status } = req.query;
@@ -149,47 +150,71 @@ router.get('/', async (req, res) => {
 
         const bookings = await Booking.find(query).sort({ date: 1, startTime: 1 }).lean();
 
-        if (!studentId) {
-            return res.json(bookings);
+        if (studentId) {
+            const mapped = bookings.map(b => {
+                if (b.leftParticipantIDs && b.leftParticipantIDs.includes(studentId)) {
+                    return { ...b, status: 'canceled' };
+                }
+                return b;
+            });
+            return res.json(mapped);
         }
 
-        const lecturerIdentifiers = [...new Set(bookings.map(b => b.lecturerId).filter(Boolean))];
-
-        const lecturers = lecturerIdentifiers.length
-            ? await User.find({
-                $or: [
-                    { email: { $in: lecturerIdentifiers } },
-                    { idNumber: { $in: lecturerIdentifiers } }
-                ],
-                role: 'lecturer'
-            }, 'name surname email idNumber').lean()
-            : [];
-
-        const lecturersByIdentifier = new Map();
-        lecturers.forEach(lecturer => {
-            const fullName = [lecturer.name, lecturer.surname].filter(Boolean).join(' ');
-            if (lecturer.email) lecturersByIdentifier.set(lecturer.email, fullName);
-            if (lecturer.idNumber) lecturersByIdentifier.set(lecturer.idNumber, fullName);
-        });
-
-        const mapped = bookings.map(b => {
-            const booking = {
-                ...b,
-                lecturerName: lecturersByIdentifier.get(b.lecturerId) || b.lecturerId || 'Unknown Lecturer'
-            };
-
-            if (b.leftParticipantIDs && b.leftParticipantIDs.includes(studentId)) {
-                return { ...booking, status: 'canceled' };
-            }
-            return booking;
-        });
-
-        res.json(mapped);
+        res.json(bookings);
     } catch (error) {
         console.error(error);
         res.status(500).json({ error: 'Failed to fetch bookings' });
     }
-}); 
+});
+
+    const rawBookings = await Booking.find({
+      $or: [
+        { participantIDs: studentId },
+        { leftParticipantIDs: studentId }
+      ]
+    }).sort({ date: 1, startTime: 1 }).lean()
+
+    const lecturerIdentifiers = [...new Set(rawBookings.map(b => b.lecturerId).filter(Boolean))]
+
+    // FIX: Search by both email AND idNumber since lecturerId contains the staff numeric ID
+    const lecturers = lecturerIdentifiers.length
+      ? await User.find({
+        $or: [
+          { email: { $in: lecturerIdentifiers } },
+          { idNumber: { $in: lecturerIdentifiers } }
+        ],
+        role: 'lecturer'
+      }, 'name surname email idNumber').lean()
+      : []
+
+    // Map names to both their email and idNumber for a bulletproof fallback lookup
+    const lecturersByIdentifier = new Map()
+    lecturers.forEach(lecturer => {
+      const fullName = [lecturer.name, lecturer.surname].filter(Boolean).join(' ')
+      if (lecturer.email) lecturersByIdentifier.set(lecturer.email, fullName)
+      if (lecturer.idNumber) lecturersByIdentifier.set(lecturer.idNumber, fullName)
+    })
+
+    // Dynamically override the status to 'canceled' on the user's side if they left
+    const bookings = rawBookings.map(b => {
+      const booking = {
+        ...b,
+        // FIX: Grab the mapped name using the identifier map
+        lecturerName: lecturersByIdentifier.get(b.lecturerId) || b.lecturerId || 'Unknown Lecturer'
+      }
+
+      if (b.leftParticipantIDs && b.leftParticipantIDs.includes(studentId)) {
+        return { ...booking, status: 'canceled' }
+      }
+      return booking
+    })
+
+    res.json(bookings)
+  } catch (error) {
+    console.error(error)
+    res.status(500).json({ error: 'Failed to fetch bookings' })
+  }
+})
 
 // DELETE: Cancel a booking (Now handles smart cancellation)
 router.delete('/:id', async (req, res) => {

--- a/tests/unit/students-joining.test.js
+++ b/tests/unit/students-joining.test.js
@@ -18,6 +18,39 @@ global.localStorage = {
     clear() { this.store = {}; }
 };
 
+const testSessions = [
+    {
+        _id: '1',
+        module: 'ELEN4010',
+        date: new Date().toISOString().split('T')[0],
+        startTime: '10:00',
+        status: 'upcoming',
+        studentId: 'alice@uni.edu',
+        topic: 'Arrays',
+        participantIDs: [],
+        lecturerId: 'dr.smith@uni.edu'
+    },
+    {
+        _id: '2',
+        module: 'ELEN4006',
+        date: new Date().toISOString().split('T')[0],
+        startTime: '11:00',
+        status: 'ongoing',
+        studentId: 'bob@uni.edu',
+        topic: 'Sorting',
+        participantIDs: ['bob@uni.edu'],
+        lecturerId: 'dr.jones@uni.edu'
+    }
+];
+
+global.fetch = jest.fn(() =>
+    Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(testSessions)
+    })
+);
+
+
 beforeEach(() => {
     document.body.innerHTML = `
         <div id="sessions-list"></div>
@@ -54,63 +87,61 @@ afterAll(() => {
 });
 
 describe('Join Peer Session - Epic #4', () => {
-    const testSessions = [
-        {
-            id: '1',
-            courseCode: 'ELEN4010',
-            date: new Date().toISOString().split('T')[0],
-            time: '10:00',
-            duration: 30,
-            status: 'upcoming',
-            studentName: 'Alice',
-            topic: 'Arrays',
-            joinedStudents: [],
-            lecturerName: 'Dr. Smith'
-        },
-        {
-            id: '2',
-            courseCode: 'ELEN4006',
-            date: new Date().toISOString().split('T')[0],
-            time: '11:00',
-            duration: 45,
-            status: 'ongoing',
-            studentName: 'Bob',
-            topic: 'Sorting',
-            joinedStudents: ['Bob'],
-            lecturerName: 'Dr. Jones'
-        }
-    ];
-
     beforeEach(() => {
-        global.localStorage.setItem('sychro_consultations', JSON.stringify(testSessions));
         global.sessionStorage.setItem('sychro_current_user', JSON.stringify({
             fullName: 'Carol',
             email: 'carol@uni.edu'
         }));
     });
 
-    test('should add student name to joinedStudents on join', () => {
-        const joiner = new StudentSessionJoiner();
-        joiner.joinSession('1');
+    test('should call API to join session', async () => {
+        global.fetch.mockClear();
+        // First call: loadSessions on init
+        // Second call: join request
+        // Third call: reload sessions after join
+        global.fetch
+            .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(testSessions) })
+            .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true }) })
+            .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(testSessions) });
 
-        const stored = JSON.parse(global.localStorage.getItem('sychro_consultations'));
-        expect(stored[0].joinedStudents).toContain('Carol');
+        const joiner = new StudentSessionJoiner();
+        await joiner.init();
+
+        await joiner.joinSession('1');
+
+        expect(global.fetch).toHaveBeenCalledWith('/api/bookings/1/join', expect.objectContaining({
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email: 'carol@uni.edu' })
+        }));
     });
 
-    test('should not add duplicate entry', () => {
-        const joiner = new StudentSessionJoiner();
-        joiner.joinSession('1');
-        joiner.joinSession('1');
+    test('should reload sessions after joining', async () => {
+        global.fetch
+            .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(testSessions) })
+            .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true }) })
+            .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(testSessions) });
 
-        const stored = JSON.parse(global.localStorage.getItem('sychro_consultations'));
-        expect(stored[0].joinedStudents.filter(n => n === 'Carol').length).toBe(1);
+        const joiner = new StudentSessionJoiner();
+        await joiner.init();
+        await joiner.joinSession('1');
+
+        // Should have called GET /api/bookings twice (init + reload after join)
+        const getCalls = global.fetch.mock.calls.filter(call => 
+            call[0] === '/api/bookings?status=upcoming,ongoing'
+        );
+        expect(getCalls.length).toBeGreaterThanOrEqual(2);
     });
 
-    test('should show "Joined" button after joining', () => {
+    test('should show alert if not logged in', async () => {
+        global.sessionStorage.clear();
+        global.fetch
+            .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(testSessions) });
+
         const joiner = new StudentSessionJoiner();
-        joiner.joinSession('1');
-        joiner.filterAndRender(); // re-render
-        const html = document.getElementById('sessions-list').innerHTML;
-        expect(html).toContain('Joined');
+        await joiner.init();
+        await joiner.joinSession('1');
+
+        expect(global.alert).toHaveBeenCalledWith('You must be logged in to join a session.');
     });
 });


### PR DESCRIPTION
## Fix: Student Join Session Existing - Connect to Database

### Problem
`students-joining.js` was reading from `localStorage` and using old field names (`joinedStudents`, `courseCode`, `studentName`). Students couldn't join sessions because data was saved to browser storage instead of MongoDB.

### Changes
- Replaced `localStorage` with API calls to `/api/bookings`
- Updated all field names to match the Booking model (`participantIDs`, `module`, `studentId`, `lecturerId`, `_id`)
- `loadSessions()` fetches from `GET /api/bookings?status=upcoming,ongoing`
- `joinSession()` sends `PUT /api/bookings/:id/join` with student email
- `renderCard()` uses `session.participantIDs` and checks by email
- `init()` and refresh button are now async

### Files Changed
- `public/js/students-joining.js` — Database-connected join logic
- `src/routes/bookings.js` — Added `PUT /:id/join` route