### PR TITLE
fix: notify lecturers of booking lifecycle changes

### DIFF
--- a/email-log.txt
+++ b/email-log.txt
@@ -104,3 +104,354 @@ Topic: topic
 
 You can view this booking from your student dashboard.
 ------------------------------------------------------------------------
+[2026-05-17T13:28:06.251Z] TO: 7778899@students.com | SUBJECT: Consultation booking canceled
+Hi Gangstar,
+
+Your consultation booking has been canceled.
+
+Module: ELEN2016-ELECTRONICS
+Date: 2026-05-18
+Time: 15:00 - 15:25
+Venue: RS227
+Topic: Control PID
+
+You can view your bookings from your student dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:28:53.138Z] TO: ofenembe@gmail.com | SUBJECT: Student joined your consultation
+Hi Ofentse,
+
+Gangstar Shubile has joined your consultation.
+
+Module: ELEN4010A
+Date: 2026-05-18
+Time: 10:00 - 11:00
+Venue: Hall 29
+Topic: topic
+
+You can view this session from your lecturer dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:28:53.430Z] TO: 7778899@students.com | SUBJECT: You joined a consultation
+Hi Gangstar,
+
+You have successfully joined this consultation.
+
+Module: ELEN4010A
+Date: 2026-05-18
+Time: 10:00 - 11:00
+Venue: Hall 29
+Topic: topic
+
+You can view your bookings from your student dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:31:26.252Z] TO: 7778899@students.com | SUBJECT: You left a consultation
+Hi Gangstar,
+
+You have left this consultation. It remains active for the other students.
+
+Module: ELEN4010A
+Date: 2026-05-18
+Time: 10:00 - 11:00
+Venue: Hall 29
+Topic: topic
+
+You can view your bookings from your student dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:31:58.758Z] TO: ofenembe@gmail.com | SUBJECT: Student joined your consultation
+Hi Ofentse,
+
+Gangstar Shubile has joined your consultation.
+
+Module: ELEN4010A
+Date: 2026-05-18
+Time: 10:00 - 11:00
+Venue: Hall 29
+Topic: topic
+
+You can view this session from your lecturer dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:31:58.866Z] TO: 7778899@students.com | SUBJECT: You joined a consultation
+Hi Gangstar,
+
+You have successfully joined this consultation.
+
+Module: ELEN4010A
+Date: 2026-05-18
+Time: 10:00 - 11:00
+Venue: Hall 29
+Topic: topic
+
+You can view your bookings from your student dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:41:17.365Z] TO: ngcweti.mjiyako@gmail.com | SUBJECT: Consultation booking confirmed
+Hi Mthiyane,
+
+Your consultation booking has been confirmed.
+
+Module: ELEN2016-ELECTRONICS
+Date: 2026-05-18
+Time: 15:00 - 15:25
+Venue: RS227
+Topic: yes
+
+You can view this booking from your student dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:42:09.601Z] TO: ngcweti.mjiyako@gmail.com | SUBJECT: Consultation booking canceled
+Hi Mthiyane,
+
+Your consultation booking has been canceled.
+
+Module: ELEN2016-ELECTRONICS
+Date: 2026-05-18
+Time: 15:00 - 15:25
+Venue: RS227
+Topic: yes
+
+You can view your bookings from your student dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:42:47.157Z] TO: ngcweti.mjiyako@gmail.com | SUBJECT: Consultation booking confirmed
+Hi Mthiyane,
+
+Your consultation booking has been confirmed.
+
+Module: ELEN2016-ELECTRONICS
+Date: 2026-05-18
+Time: 15:00 - 15:25
+Venue: RS227
+Topic: 22
+
+You can view this booking from your student dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:42:50.068Z] TO: mjiyako.ngcweti@gmail.com | SUBJECT: New consultation booking
+Hi Anton,
+
+Mthiyane Mjiyako has booked one of your consultation slots.
+
+Module: ELEN2016-ELECTRONICS
+Date: 2026-05-18
+Time: 15:00 - 15:25
+Venue: RS227
+Topic: 22
+
+You can view this booking from your lecturer dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:44:06.874Z] TO: ngcweti.mjiyako@gmail.com | SUBJECT: Consultation booking canceled
+Hi Mthiyane,
+
+Your consultation booking has been canceled.
+
+Module: ELEN2016-ELECTRONICS
+Date: 2026-05-18
+Time: 15:00 - 15:25
+Venue: RS227
+Topic: 22
+
+You can view your bookings from your student dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:47:56.365Z] TO: ngcweti.mjiyako@gmail.com | SUBJECT: Consultation booking confirmed
+Hi Mthiyane,
+
+Your consultation booking has been confirmed.
+
+Module: ELEN2016-ELECTRONICS
+Date: 2026-05-18
+Time: 15:00 - 15:25
+Venue: RS227
+Topic: lets go
+
+You can view this booking from your student dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:47:59.599Z] TO: mjiyako.ngcweti@gmail.com | SUBJECT: New consultation booking
+Hi Anton,
+
+Mthiyane Mjiyako has booked one of your consultation slots.
+
+Module: ELEN2016-ELECTRONICS
+Date: 2026-05-18
+Time: 15:00 - 15:25
+Venue: RS227
+Topic: lets go
+
+You can view this booking from your lecturer dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:48:37.196Z] TO: ngcweti.mjiyako@gmail.com | SUBJECT: Consultation booking canceled
+Hi Mthiyane,
+
+Your consultation booking has been canceled.
+
+Module: ELEN2016-ELECTRONICS
+Date: 2026-05-18
+Time: 15:00 - 15:25
+Venue: RS227
+Topic: lets go
+
+You can view your bookings from your student dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:48:40.664Z] TO: mjiyako.ngcweti@gmail.com | SUBJECT: Student canceled a consultation
+Hi Anton,
+
+Mthiyane Mjiyako has canceled this consultation.
+
+Module: ELEN2016-ELECTRONICS
+Date: 2026-05-18
+Time: 15:00 - 15:25
+Venue: RS227
+Topic: lets go
+
+You can view the updated session from your lecturer dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:49:31.617Z] TO: ngcweti.mjiyako@gmail.com | SUBJECT: Consultation booking confirmed
+Hi Mthiyane,
+
+Your consultation booking has been confirmed.
+
+Module: ELEN2016-ELECTRONICS
+Date: 2026-05-18
+Time: 15:00 - 15:25
+Venue: RS227
+Topic: ulele
+
+You can view this booking from your student dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:49:35.666Z] TO: mjiyako.ngcweti@gmail.com | SUBJECT: New consultation booking
+Hi Anton,
+
+Mthiyane Mjiyako has booked one of your consultation slots.
+
+Module: ELEN2016-ELECTRONICS
+Date: 2026-05-18
+Time: 15:00 - 15:25
+Venue: RS227
+Topic: ulele
+
+You can view this booking from your lecturer dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:50:13.878Z] TO: 7778899@students.com | SUBJECT: You joined a consultation
+Hi Gangstar,
+
+You have successfully joined this consultation.
+
+Module: ELEN2016-ELECTRONICS
+Date: 2026-05-18
+Time: 15:00 - 15:25
+Venue: RS227
+Topic: ulele
+
+You can view your bookings from your student dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:50:14.062Z] TO: mjiyako.ngcweti@gmail.com | SUBJECT: Student joined your consultation
+Hi Anton,
+
+Gangstar Shubile has joined your consultation.
+
+Module: ELEN2016-ELECTRONICS
+Date: 2026-05-18
+Time: 15:00 - 15:25
+Venue: RS227
+Topic: ulele
+
+You can view this session from your lecturer dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:50:37.562Z] TO: 7778899@students.com | SUBJECT: You left a consultation
+Hi Gangstar,
+
+You have left this consultation. It remains active for the other students.
+
+Module: ELEN2016-ELECTRONICS
+Date: 2026-05-18
+Time: 15:00 - 15:25
+Venue: RS227
+Topic: ulele
+
+You can view your bookings from your student dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:50:40.486Z] TO: mjiyako.ngcweti@gmail.com | SUBJECT: Student canceled a consultation
+Hi Anton,
+
+Gangstar Shubile has left this consultation.
+
+Module: ELEN2016-ELECTRONICS
+Date: 2026-05-18
+Time: 15:00 - 15:25
+Venue: RS227
+Topic: ulele
+
+You can view the updated session from your lecturer dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:51:09.901Z] TO: 7778899@students.com | SUBJECT: You left a consultation
+Hi Gangstar,
+
+You have left this consultation. It remains active for the other students.
+
+Module: ELEN4010A
+Date: 2026-05-18
+Time: 10:00 - 11:00
+Venue: Hall 29
+Topic: topic
+
+You can view your bookings from your student dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:51:12.875Z] TO: ofenembe@gmail.com | SUBJECT: Student canceled a consultation
+Hi Ofentse,
+
+Gangstar Shubile has left this consultation.
+
+Module: ELEN4010A
+Date: 2026-05-18
+Time: 10:00 - 11:00
+Venue: Hall 29
+Topic: topic
+
+You can view the updated session from your lecturer dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:54:12.343Z] TO: 7778899@students.com | SUBJECT: You joined a consultation
+Hi Gangstar,
+
+You have successfully joined this consultation.
+
+Module: ELEN4010
+Date: 2026-05-18
+Time: 12:15 - 12:45
+Venue: WSS
+Topic: FF
+
+You can view your bookings from your student dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:54:12.425Z] TO: nhlakaniphomngomezulu55@gmail.com | SUBJECT: Student joined your consultation
+Hi Dr Nhlaks,
+
+Gangstar Shubile has joined your consultation.
+
+Module: ELEN4010
+Date: 2026-05-18
+Time: 12:15 - 12:45
+Venue: WSS
+Topic: FF
+
+You can view this session from your lecturer dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:54:39.328Z] TO: 7778899@students.com | SUBJECT: You left a consultation
+Hi Gangstar,
+
+You have left this consultation. It remains active for the other students.
+
+Module: ELEN4010
+Date: 2026-05-18
+Time: 12:15 - 12:45
+Venue: WSS
+Topic: FF
+
+You can view your bookings from your student dashboard.
+------------------------------------------------------------------------
+[2026-05-17T13:54:42.665Z] TO: nhlakaniphomngomezulu55@gmail.com | SUBJECT: Student canceled a consultation
+Hi Dr Nhlaks,
+
+Gangstar Shubile has left this consultation.
+
+Module: ELEN4010
+Date: 2026-05-18
+Time: 12:15 - 12:45
+Venue: WSS
+Topic: FF
+
+You can view the updated session from your lecturer dashboard.
+------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -36,5 +36,12 @@
     "jest-environment-jsdom": "^30.3.0",
     "nodemon": "^3.1.14",
     "supertest": "^7.2.2"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.js",
+      "!src/server.js",
+      "!src/config/db.js"
+    ]
   }
 }

--- a/public/css/lecturer-dashboard.css
+++ b/public/css/lecturer-dashboard.css
@@ -187,6 +187,10 @@ body {
     color: white;
 }
 
+.session-actions .btn-danger {
+    border-radius: 25px;
+}
+
 /* Stats Grid */
 .stats-grid {
     display: grid;

--- a/public/css/student-dashboard.css
+++ b/public/css/student-dashboard.css
@@ -202,6 +202,10 @@ body {
     color: white;
 }
 
+.session-actions .btn-rounded-cancel {
+    border-radius: 25px;
+}
+
 .stats-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));

--- a/public/js/lecturer-dashboard.js
+++ b/public/js/lecturer-dashboard.js
@@ -39,17 +39,24 @@ class LecturerScheduleManager {
   // EVENT LISTENERS
 
   setupEventListeners () {
+    if (!this.statusFilter || !this.courseFilter || !this.dateFilter || !this.searchInput || !this.scheduleList || !this.sessionModal) {
+      return
+    }
+
     this.statusFilter.addEventListener('change', () => this.handleFilterChange())
     this.courseFilter.addEventListener('change', () => this.handleFilterChange())
     this.dateFilter.addEventListener('change', () => this.handleFilterChange())
     this.searchInput.addEventListener('input', this.debounce(() => this.handleFilterChange(), 300))
 
-    document.getElementById('refresh-btn').addEventListener('click', async () => {
-      await this.loadSessions()
-      this.updateStats()
-      this.updateFilterOptions()
-      this.applyFilters()
-    })
+    const refreshBtn = document.getElementById('refresh-btn')
+    if (refreshBtn) {
+      refreshBtn.addEventListener('click', async () => {
+        await this.loadSessions()
+        this.updateStats()
+        this.updateFilterOptions()
+        this.applyFilters()
+      })
+    }
 
     this.scheduleList.addEventListener('click', (e) => {
       const button = e.target.closest('[data-session-action]')
@@ -61,7 +68,8 @@ class LecturerScheduleManager {
       if (button.dataset.sessionAction === 'complete') this.completeSession(sessionId)
     })
 
-    document.getElementById('close-session-modal').addEventListener('click', () => this.closeModal())
+    const closeModalBtn = document.getElementById('close-session-modal')
+    if (closeModalBtn) closeModalBtn.addEventListener('click', () => this.closeModal())
     this.sessionModal.addEventListener('click', (e) => {
       if (e.target === this.sessionModal) this.closeModal()
     })
@@ -224,6 +232,8 @@ class LecturerScheduleManager {
   // FILTERING
 
   applyFilters () {
+    if (!this.statusFilter || !this.courseFilter || !this.dateFilter || !this.searchInput) return
+
     const status = this.statusFilter.value
     const course = this.courseFilter.value
     const date = this.dateFilter.value
@@ -285,6 +295,8 @@ class LecturerScheduleManager {
   }
 
   updateFilterOptions () {
+    if (!this.courseFilter) return
+
     const courses = [...new Set(this.sessions.map(s => s.courseCode).filter(Boolean))].sort()
     this.courseFilter.innerHTML = '<option value="all">All Courses</option>'
     courses.forEach(course => {
@@ -298,6 +310,8 @@ class LecturerScheduleManager {
   // STATISTICS
 
   updateStats () {
+    if (!this.totalSessionsEl || !this.totalJoinedEl || !this.upcomingCountEl || !this.completedTodayEl) return
+
     const today = new Date().toISOString().split('T')[0]
     const todaySessions = this.sessions.filter(s => s.date === today)
 
@@ -311,6 +325,7 @@ class LecturerScheduleManager {
 
   displayCurrentDate () {
     const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }
+    if (!this.currentDateEl) return
     this.currentDateEl.textContent = new Date().toLocaleDateString('en-US', options)
   }
 
@@ -325,6 +340,8 @@ class LecturerScheduleManager {
   }
 
   render () {
+    if (!this.scheduleList || !this.emptyState) return
+
     if (this.filteredSessions.length === 0) {
       this.scheduleList.innerHTML = ''
       this.emptyState.classList.remove('hidden')

--- a/public/js/register-page.js
+++ b/public/js/register-page.js
@@ -25,7 +25,9 @@ registerform.addEventListener('submit', (e) => {
   const roleSegment = document.querySelector('#role')
 
   // Get the currently selected value ('student' or 'lecturer')
-  const selectedRole = roleSegment.value
+  const selectedRole = roleSegment
+    ? roleSegment.value
+    : document.querySelector('input[name="roleOptions"]:checked')?.value
 
   console.log('Registering as:', selectedRole)
 })

--- a/public/js/student-dashboard.js
+++ b/public/js/student-dashboard.js
@@ -303,7 +303,7 @@ class StudentScheduleManager {
                 <div class="session-actions">
                     ${session.status === 'upcoming'
 ? `
-                        <button class="btn btn-sm btn-danger" onclick="scheduleManager.cancelBooking('${session.id}')">
+                        <button class="btn btn-sm btn-danger btn-rounded-cancel" onclick="scheduleManager.cancelBooking('${session.id}')">
                             <i class="fas fa-times"></i> Cancel
                         </button>
                     `

--- a/src/routes/activities.js
+++ b/src/routes/activities.js
@@ -87,24 +87,54 @@ function activityMatchesRequester(activity, requester) {
     if (requester.values.length === 0) return false;
 
     const metadata = activity.metadata || {};
-    const searchableValues = [
+    const audienceValues = [
+        ...(Array.isArray(metadata.audienceIds) ? metadata.audienceIds : []),
+        ...(Array.isArray(metadata.audienceEmails) ? metadata.audienceEmails : [])
+    ];
+    const actorValues = [
         activity.userId,
         activity.userEmail,
         metadata.userId,
         metadata.userEmail,
         metadata.actorId,
-        metadata.actorEmail,
+        metadata.actorEmail
+    ];
+    const studentValues = [
         metadata.studentId,
         metadata.studentEmail,
-        metadata.lecturerId,
-        metadata.lecturerEmail,
         ...(Array.isArray(metadata.participantIDs) ? metadata.participantIDs : []),
-        ...(Array.isArray(metadata.participantEmails) ? metadata.participantEmails : []),
-        ...(Array.isArray(metadata.audienceIds) ? metadata.audienceIds : []),
-        ...(Array.isArray(metadata.audienceEmails) ? metadata.audienceEmails : [])
-    ].filter(Boolean).map(String);
+        ...(Array.isArray(metadata.participantEmails) ? metadata.participantEmails : [])
+    ];
+    const lecturerValues = [
+        metadata.lecturerId,
+        metadata.lecturerEmail
+    ];
+    const actorRole = activity.userRole || metadata.userRole || '';
 
-    return requester.values.some(value => searchableValues.includes(String(value)));
+    let searchableValues;
+    if (requester.role === 'student') {
+        searchableValues = [
+            ...studentValues,
+            ...audienceValues,
+            ...(actorRole === 'student' ? actorValues : [])
+        ];
+    } else if (requester.role === 'lecturer') {
+        searchableValues = [
+            ...lecturerValues,
+            ...audienceValues,
+            ...(actorRole === 'lecturer' ? actorValues : [])
+        ];
+    } else {
+        searchableValues = [
+            ...actorValues,
+            ...studentValues,
+            ...lecturerValues,
+            ...audienceValues
+        ];
+    }
+
+    const normalizedValues = searchableValues.filter(Boolean).map(String);
+    return requester.values.some(value => normalizedValues.includes(String(value)));
 }
 
 function getActivityCourse(activity) {

--- a/src/routes/bookings.js
+++ b/src/routes/bookings.js
@@ -25,7 +25,7 @@ function formatStudentDisplayName (student) {
 }
 
 async function logBookingActivity (activity) {
-  if (process.env.NODE_ENV === 'test') {
+  if (process.env.NODE_ENV === 'test' && !Activity.create?._isMockFunction && Activity.db?.readyState === 0) {
     return
   }
 
@@ -41,7 +41,7 @@ async function logBookingActivity (activity) {
 
 async function sendStudentBookingConfirmation (studentIdentifier, booking) {
   if (process.env.NODE_ENV === 'test' && !User.findOne?._isMockFunction && User.db?.readyState === 0) {
-    return
+    return null
   }
 
   try {
@@ -55,7 +55,7 @@ async function sendStudentBookingConfirmation (studentIdentifier, booking) {
 
     if (!student) {
       console.warn(`Booking confirmation skipped: student not found for ${studentIdentifier}`)
-      return
+      return null
     }
 
     await sendNotification(
@@ -75,8 +75,10 @@ async function sendStudentBookingConfirmation (studentIdentifier, booking) {
         'You can view this booking from your student dashboard.'
       ].join('\n')
     )
+    return student
   } catch (error) {
     console.error('Failed to send booking confirmation email:', error.message)
+    return null
   }
 }
 
@@ -126,17 +128,63 @@ async function findLecturerUserByIdentifier (identifier) {
   }
 
   try {
+    const queryConditions = [
+      { email: identifier },
+      { idNumber: identifier }
+    ]
+
+    if (!isNaN(identifier)) {
+      queryConditions.push({ idNumber: Number(identifier) })
+    }
+
     return await User.findOne({
       role: 'lecturer',
-      $or: [
-        { email: identifier },
-        { idNumber: identifier }
-      ]
+      $or: queryConditions
     })
   } catch (error) {
     console.error('Failed to find lecturer for email notification:', error.message)
     return null
   }
+}
+
+async function notifyLecturerBookingCreated (studentIdentifier, booking, student = null) {
+  const lecturer = await findLecturerUserByIdentifier(booking.lecturerId)
+  if (!lecturer) return
+
+  const studentName = student
+    ? [student.name, student.surname].filter(Boolean).join(' ') || student.email
+    : studentIdentifier
+
+  await sendNotification(
+    lecturer,
+    'New consultation booking',
+    bookingEmailBody(
+      `Hi ${lecturer.name || 'there'},\n\n${studentName} has booked one of your consultation slots.`,
+      booking,
+      'You can view this booking from your lecturer dashboard.'
+    )
+  )
+}
+
+async function notifyLecturerStudentCanceled (studentIdentifier, booking, actionText = 'canceled') {
+  const lecturer = await findLecturerUserByIdentifier(booking.lecturerId)
+  if (!lecturer) return
+
+  const students = await findStudentUsersByIdentifiers([studentIdentifier])
+  const student = students[0]
+  const studentName = student
+    ? [student.name, student.surname].filter(Boolean).join(' ') || student.email
+    : studentIdentifier
+
+  await sendNotification(
+    lecturer,
+    'Student canceled a consultation',
+    bookingEmailBody(
+      `Hi ${lecturer.name || 'there'},\n\n${studentName} has ${actionText} this consultation.`,
+      booking,
+      'You can view the updated session from your lecturer dashboard.'
+    )
+  )
 }
 
 async function notifyStudentsOfCancellation (studentIdentifiers, booking, subject, intro) {
@@ -345,7 +393,8 @@ async function createBooking (req, res) {
     })
 
     const savedBooking = await newBooking.save()
-    await sendStudentBookingConfirmation(req.body.studentId, savedBooking)
+    const student = await sendStudentBookingConfirmation(req.body.studentId, savedBooking)
+    await notifyLecturerBookingCreated(req.body.studentId, savedBooking, student)
     await logBookingActivity({
       type: 'created',
       description: `Booked ${savedBooking.module || 'consultation'} consultation`,
@@ -440,9 +489,12 @@ router.get('/', async (req, res) => {
     // FIX: Search by both email AND idNumber since lecturerId contains the staff numeric ID
     const lecturers = lecturerIdentifiers.length
       ? await User.find({
-        email: { $in: lecturerIdentifiers },
-        role: 'lecturer'
-      }, 'name surname email').lean()
+        role: 'lecturer',
+        $or: [
+          { email: { $in: lecturerIdentifiers } },
+          { idNumber: { $in: lecturerIdentifiers } }
+        ]
+      }, 'name surname email idNumber').lean()
       : []
 
     // Map names to both their email and idNumber for a bulletproof fallback lookup
@@ -450,6 +502,7 @@ router.get('/', async (req, res) => {
     lecturers.forEach(lecturer => {
       const fullName = [lecturer.name, lecturer.surname].filter(Boolean).join(' ')
       if (lecturer.email) lecturersByIdentifier.set(lecturer.email, fullName)
+      if (lecturer.idNumber) lecturersByIdentifier.set(lecturer.idNumber, fullName)
     })
 
     // Dynamically override the status to 'canceled' on the user's side if they left
@@ -460,7 +513,9 @@ router.get('/', async (req, res) => {
         lecturerName: lecturersByIdentifier.get(b.lecturerId) || b.lecturerId || 'Unknown Lecturer'
       }
 
-      if (b.leftParticipantIDs && b.leftParticipantIDs.includes(studentId)) {
+      const isParticipant = Array.isArray(b.participantIDs) && b.participantIDs.includes(studentId)
+      const hasLeft = Array.isArray(b.leftParticipantIDs) && b.leftParticipantIDs.includes(studentId)
+      if (hasLeft && !isParticipant) {
         return { ...booking, status: 'canceled' }
       }
       return booking
@@ -499,6 +554,7 @@ router.delete('/:id', async (req, res) => {
         'Consultation booking canceled',
         'Your consultation booking has been canceled.'
       )
+      await notifyLecturerStudentCanceled(studentEmail, booking)
       await logBookingActivity({
         type: 'canceled',
         description: `Canceled ${booking.module || 'consultation'} booking`,
@@ -536,6 +592,7 @@ router.delete('/:id', async (req, res) => {
         'Consultation booking canceled',
         'Your consultation booking has been canceled.'
       )
+      await notifyLecturerStudentCanceled(studentEmail, booking)
       await logBookingActivity({
         type: 'canceled',
         description: `Canceled ${booking.module || 'consultation'} booking`,
@@ -563,6 +620,7 @@ router.delete('/:id', async (req, res) => {
       'You left a consultation',
       'You have left this consultation. It remains active for the other students.'
     )
+    await notifyLecturerStudentCanceled(studentEmail, booking, 'left')
     await logBookingActivity({
       type: 'canceled',
       description: `Left ${booking.module || 'consultation'} booking`,
@@ -604,13 +662,34 @@ router.put('/:id/join', async (req, res) => {
       return res.status(400).json({ success: false, message: 'This session is already full' })
     }
 
-    await Booking.findByIdAndUpdate(req.params.id, {
-      $addToSet: { participantIDs: email }
-    })
+    const joinUpdate = {
+      $addToSet: { participantIDs: email },
+      $pull: { leftParticipantIDs: email }
+    }
+    if (booking.status === 'canceled') {
+      joinUpdate.$set = { status: 'upcoming' }
+    }
+
+    await Booking.findByIdAndUpdate(req.params.id, joinUpdate)
     await Promise.all([
       notifyStudentJoinedConsultation(email, booking),
       notifyLecturerStudentJoined(email, booking)
     ])
+    await logBookingActivity({
+      type: 'joined',
+      description: `Joined ${booking.module || 'consultation'} consultation`,
+      user: email,
+      userId: email,
+      userEmail: email,
+      userRole: 'student',
+      metadata: bookingActivityMetadata(booking, {
+        actorId: email,
+        actorEmail: email,
+        userRole: 'student',
+        audienceIds: uniqueValues([booking.studentId, booking.lecturerId, email, ...participants]),
+        audienceEmails: uniqueValues([booking.studentId, booking.lecturerId, email, ...participants])
+      })
+    })
 
     res.json({ success: true, message: 'Successfully joined the session.' })
   } catch (error) {
@@ -646,6 +725,7 @@ router.put('/leave/:id', async (req, res) => {
         'Consultation booking canceled',
         'Your consultation booking has been canceled.'
       )
+      await notifyLecturerStudentCanceled(email, booking)
       await logBookingActivity({
         type: 'canceled',
         description: `Canceled ${booking.module || 'consultation'} session`,
@@ -673,6 +753,7 @@ router.put('/leave/:id', async (req, res) => {
       'You left a consultation',
       'You have left this consultation. It remains active for the other students.'
     )
+    await notifyLecturerStudentCanceled(email, booking, 'left')
     await logBookingActivity({
       type: 'canceled',
       description: `Left ${booking.module || 'consultation'} session`,

--- a/tests/acceptance/user-flows.test.js
+++ b/tests/acceptance/user-flows.test.js
@@ -133,8 +133,14 @@ describe('User Acceptance Flows', () => {
     expect(sort).toHaveBeenCalledWith({ date: 1, startTime: 1 });
     expect(lean).toHaveBeenCalled();
     expect(User.find).toHaveBeenCalledWith(
-      { email: { $in: [booking.lecturerId] }, role: 'lecturer' },
-      'name surname email'
+      {
+        role: 'lecturer',
+        $or: [
+          { email: { $in: [booking.lecturerId] } },
+          { idNumber: { $in: [booking.lecturerId] } }
+        ]
+      },
+      'name surname email idNumber'
     );
 
     const cancelResponse = await request(app)

--- a/tests/integration/activity-integration.test.js
+++ b/tests/integration/activity-integration.test.js
@@ -163,4 +163,118 @@ describe('Activity API', () => {
     expect(response.status).toBe(200);
     expect(response.body.map(activity => activity.metadata.course)).toContain('COMS3009');
   });
+
+  it('limits student activity to bookings involving that student only', async () => {
+    mockActivityFind([
+      {
+        _id: 'activity-1',
+        type: 'created',
+        description: 'Booked ELEN4010 consultation',
+        user: 'student@wits.ac.za',
+        userId: 'student@wits.ac.za',
+        userEmail: 'student@wits.ac.za',
+        userRole: 'student',
+        timestamp: '2026-05-16T08:00:00.000Z',
+        metadata: {
+          course: 'ELEN4010',
+          studentId: 'student@wits.ac.za',
+          studentEmail: 'student@wits.ac.za',
+          lecturerId: 'lecturer@wits.ac.za',
+          lecturerEmail: 'lecturer@wits.ac.za',
+          audienceIds: ['student@wits.ac.za', 'lecturer@wits.ac.za'],
+          audienceEmails: ['student@wits.ac.za', 'lecturer@wits.ac.za']
+        }
+      },
+      {
+        _id: 'activity-2',
+        type: 'created',
+        description: 'Booked ELEN4010 consultation for another student',
+        user: 'other@wits.ac.za',
+        userId: 'other@wits.ac.za',
+        userEmail: 'other@wits.ac.za',
+        userRole: 'student',
+        timestamp: '2026-05-16T09:00:00.000Z',
+        metadata: {
+          course: 'ELEN4010',
+          studentId: 'other@wits.ac.za',
+          studentEmail: 'other@wits.ac.za',
+          lecturerId: 'lecturer@wits.ac.za',
+          lecturerEmail: 'lecturer@wits.ac.za',
+          audienceIds: ['other@wits.ac.za', 'lecturer@wits.ac.za'],
+          audienceEmails: ['other@wits.ac.za', 'lecturer@wits.ac.za']
+        }
+      }
+    ]);
+    mockBookingFind([]);
+    mockAvailabilityFind([]);
+
+    const response = await request(app)
+      .get('/api/activities')
+      .set('X-User-Email', 'student@wits.ac.za')
+      .set('X-User-Id', 'student@wits.ac.za')
+      .set('X-User-Role', 'student');
+
+    expect(response.status).toBe(200);
+    expect(response.body.map(activity => activity.id)).toEqual(['activity-1']);
+    expect(response.body.map(activity => activity.id)).not.toContain('activity-2');
+  });
+
+  it('limits lecturer activity to records involving that lecturer only', async () => {
+    mockActivityFind([
+      {
+        _id: 'activity-1',
+        type: 'created',
+        description: 'Booked ELEN4010 consultation',
+        user: 'student@wits.ac.za',
+        userId: 'student@wits.ac.za',
+        userEmail: 'student@wits.ac.za',
+        userRole: 'student',
+        timestamp: '2026-05-16T08:00:00.000Z',
+        metadata: {
+          course: 'ELEN4010',
+          studentId: 'student@wits.ac.za',
+          lecturerId: 'lecturer@wits.ac.za',
+          lecturerEmail: 'lecturer@wits.ac.za',
+          audienceIds: ['student@wits.ac.za', 'lecturer@wits.ac.za'],
+          audienceEmails: ['student@wits.ac.za', 'lecturer@wits.ac.za']
+        }
+      },
+      {
+        _id: 'activity-2',
+        type: 'created',
+        description: 'Booked ELEN4010 consultation with another lecturer',
+        user: 'other@wits.ac.za',
+        userId: 'other@wits.ac.za',
+        userEmail: 'other@wits.ac.za',
+        userRole: 'student',
+        timestamp: '2026-05-16T09:00:00.000Z',
+        metadata: {
+          course: 'ELEN4010',
+          studentId: 'other@wits.ac.za',
+          lecturerId: 'other-lecturer@wits.ac.za',
+          lecturerEmail: 'other-lecturer@wits.ac.za',
+          audienceIds: ['other@wits.ac.za', 'other-lecturer@wits.ac.za'],
+          audienceEmails: ['other@wits.ac.za', 'other-lecturer@wits.ac.za']
+        }
+      }
+    ]);
+    mockBookingFind([]);
+    mockAvailabilityFind([
+      {
+        lecturerEmail: 'lecturer@wits.ac.za',
+        courses: ['ELEN4010'],
+        weeklySchedule: []
+      }
+    ]);
+
+    const response = await request(app)
+      .get('/api/activities')
+      .set('X-User-Email', 'lecturer@wits.ac.za')
+      .set('X-User-Id', 'lecturer@wits.ac.za')
+      .set('X-User-Role', 'lecturer');
+
+    expect(response.status).toBe(200);
+    expect(response.body.map(activity => activity.id)).toEqual(['activity-1']);
+    expect(response.body.map(activity => activity.id)).not.toContain('activity-2');
+  });
 });

--- a/tests/integration/availability-integration.test.js
+++ b/tests/integration/availability-integration.test.js
@@ -24,9 +24,11 @@ class MockAvailability {
   }
 
   static cloneDay(day) {
+    const slots = (day.slots || []).map(MockAvailability.cloneSlot);
+    slots.id = id => slots.find(slot => slot._id.toString() === id) || null;
     return {
       dayOfWeek: day.dayOfWeek,
-      slots: (day.slots || []).map(MockAvailability.cloneSlot),
+      slots,
     };
   }
 
@@ -392,6 +394,153 @@ describe('Availability API Integration Tests', () => {
 
       expect(res.status).toBe(404);
       expect(res.body.message).toBe('Slot not found');
+    });
+  });
+
+  describe('PUT /api/availability/slot/:slotId', () => {
+    let slotId;
+
+    beforeEach(async () => {
+      const schedule = await Availability.create({
+        lecturerEmail: testLecturerEmail,
+        lecturerName: 'Test Lecturer',
+        weeklySchedule: [
+          {
+            dayOfWeek: 2,
+            slots: [
+              {
+                start: '09:00',
+                end: '10:00',
+                duration: 60,
+                course: 'MATH101',
+                venue: 'Room 101',
+                maxStudents: 5,
+              },
+              {
+                start: '11:00',
+                end: '12:00',
+                duration: 60,
+                course: 'PHYS101',
+                venue: 'Lab 1',
+                maxStudents: 3,
+              },
+            ],
+          },
+        ],
+        courses: ['MATH101', 'PHYS101'],
+      });
+      slotId = schedule.weeklySchedule[0].slots[0]._id.toString();
+    });
+
+    it('updates an existing slot and refreshes the course list', async () => {
+      const res = await request(app)
+        .put(`/api/availability/slot/${slotId}`)
+        .set('X-Lecturer-Id', testLecturerEmail)
+        .send({
+          dayOfWeek: 2,
+          start: '09:30',
+          end: '10:30',
+          duration: 60,
+          course: 'chem101',
+          venue: ' Lab 7 ',
+          maxStudents: 4,
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Slot updated successfully');
+
+      const updated = await Availability.findOne({ lecturerEmail: testLecturerEmail });
+      expect(updated.weeklySchedule[0].slots[0]).toMatchObject({
+        start: '09:30',
+        end: '10:30',
+        duration: 60,
+        course: 'CHEM101',
+        venue: 'Lab 7',
+        maxStudents: 4,
+      });
+      expect(updated.courses).toEqual(['CHEM101', 'PHYS101']);
+    });
+
+    it('rejects slot updates without a lecturer id', async () => {
+      const res = await request(app)
+        .put(`/api/availability/slot/${slotId}`)
+        .send({ dayOfWeek: 2 });
+
+      expect(res.status).toBe(401);
+      expect(res.body.message).toBe('Unauthorized');
+    });
+
+    it('rejects slot updates with missing fields, invalid days, and invalid time ranges', async () => {
+      const missing = await request(app)
+        .put(`/api/availability/slot/${slotId}`)
+        .set('X-Lecturer-Id', testLecturerEmail)
+        .send({ dayOfWeek: 2 });
+
+      const invalidDay = await request(app)
+        .put(`/api/availability/slot/${slotId}`)
+        .set('X-Lecturer-Id', testLecturerEmail)
+        .send({ dayOfWeek: 6, start: '09:00', end: '10:00', duration: 60, course: 'MATH101', venue: 'Room', maxStudents: 1 });
+
+      const invalidTime = await request(app)
+        .put(`/api/availability/slot/${slotId}`)
+        .set('X-Lecturer-Id', testLecturerEmail)
+        .send({ dayOfWeek: 2, start: '11:00', end: '10:00', duration: 60, course: 'MATH101', venue: 'Room', maxStudents: 1 });
+
+      expect(missing.status).toBe(400);
+      expect(missing.body.message).toBe('Missing required fields');
+      expect(invalidDay.status).toBe(400);
+      expect(invalidDay.body.message).toBe('Invalid day of week (must be 1-5)');
+      expect(invalidTime.status).toBe(400);
+      expect(invalidTime.body.message).toBe('Start time must be before end time');
+    });
+
+    it('returns 404 when updating a missing schedule, day, or slot', async () => {
+      await Availability.deleteMany({});
+
+      const missingSchedule = await request(app)
+        .put(`/api/availability/slot/${slotId}`)
+        .set('X-Lecturer-Id', testLecturerEmail)
+        .send({ dayOfWeek: 2, start: '09:00', end: '10:00', duration: 60, course: 'MATH101', venue: 'Room', maxStudents: 1 });
+
+      await Availability.create({
+        lecturerEmail: testLecturerEmail,
+        weeklySchedule: [{ dayOfWeek: 3, slots: [] }],
+      });
+
+      const missingDay = await request(app)
+        .put(`/api/availability/slot/${slotId}`)
+        .set('X-Lecturer-Id', testLecturerEmail)
+        .send({ dayOfWeek: 2, start: '09:00', end: '10:00', duration: 60, course: 'MATH101', venue: 'Room', maxStudents: 1 });
+
+      const missingSlot = await request(app)
+        .put(`/api/availability/slot/${new mongoose.Types.ObjectId()}`)
+        .set('X-Lecturer-Id', testLecturerEmail)
+        .send({ dayOfWeek: 3, start: '09:00', end: '10:00', duration: 60, course: 'MATH101', venue: 'Room', maxStudents: 1 });
+
+      expect(missingSchedule.status).toBe(404);
+      expect(missingSchedule.body.message).toBe('Schedule not found');
+      expect(missingDay.status).toBe(404);
+      expect(missingDay.body.message).toBe('Day not found');
+      expect(missingSlot.status).toBe(404);
+      expect(missingSlot.body.message).toBe('Slot not found');
+    });
+
+    it('rejects updates that overlap another slot on the same day', async () => {
+      const res = await request(app)
+        .put(`/api/availability/slot/${slotId}`)
+        .set('X-Lecturer-Id', testLecturerEmail)
+        .send({
+          dayOfWeek: 2,
+          start: '11:30',
+          end: '12:30',
+          duration: 60,
+          course: 'MATH101',
+          venue: 'Room 101',
+          maxStudents: 5,
+        });
+
+      expect(res.status).toBe(409);
+      expect(res.body.message).toContain('Time conflict');
     });
   });
 });

--- a/tests/integration/booking-integration.test.js
+++ b/tests/integration/booking-integration.test.js
@@ -30,10 +30,15 @@ jest.mock('../../src/utils/emailService', () => ({
   sendNotification: jest.fn()
 }))
 
+jest.mock('../../src/models/activity', () => ({
+  create: jest.fn()
+}))
+
 const app = require('../../src/app')
 const Booking = require('../../src/models/booking')
 const Availability = require('../../src/models/Availability')
 const User = require('../../src/models/user')
+const Activity = require('../../src/models/activity')
 const { sendNotification } = require('../../src/utils/emailService')
 
 describe('Booking Integration Tests', () => {
@@ -56,10 +61,16 @@ describe('Booking Integration Tests', () => {
 
     Booking.countDocuments.mockResolvedValue(0)
     Booking.prototype.save.mockResolvedValue(savedBooking)
-    User.findOne.mockResolvedValue({
+    User.findOne.mockResolvedValueOnce({
       name: 'Jane',
       email: 'jane.in.database@wits.ac.za',
       role: 'student',
+      emailNotifications: true
+    }).mockResolvedValueOnce({
+      name: 'Stephen',
+      surname: 'Mokoena',
+      email: 'lecturer@wits.ac.za',
+      role: 'lecturer',
       emailNotifications: true
     })
 
@@ -97,6 +108,16 @@ describe('Booking Integration Tests', () => {
       expect.objectContaining({ email: 'jane.in.database@wits.ac.za' }),
       'Consultation booking confirmed',
       expect.stringContaining('ELEN4010')
+    )
+    expect(sendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'lecturer@wits.ac.za' }),
+      'New consultation booking',
+      expect.stringContaining('Jane has booked one of your consultation slots.')
+    )
+    expect(sendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'lecturer@wits.ac.za' }),
+      'New consultation booking',
+      expect.stringContaining('You can view this booking from your lecturer dashboard.')
     )
   })
 
@@ -319,7 +340,8 @@ describe('Booking Integration Tests', () => {
     expect(response.status).toBe(200)
     expect(response.body.success).toBe(true)
     expect(Booking.findByIdAndUpdate).toHaveBeenCalledWith('booking-1', {
-      $addToSet: { participantIDs: 'newstudent@wits.ac.za' }
+      $addToSet: { participantIDs: 'newstudent@wits.ac.za' },
+      $pull: { leftParticipantIDs: 'newstudent@wits.ac.za' }
     })
     expect(sendNotification).toHaveBeenCalledWith(
       expect.objectContaining({ email: 'newstudent@wits.ac.za' }),
@@ -331,6 +353,83 @@ describe('Booking Integration Tests', () => {
       'Student joined your consultation',
       expect.stringContaining('New Student has joined your consultation.')
     )
+    expect(Activity.create).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'joined',
+      description: 'Joined ELEN50 consultation',
+      user: 'newstudent@wits.ac.za',
+      userId: 'newstudent@wits.ac.za',
+      userEmail: 'newstudent@wits.ac.za',
+      userRole: 'student',
+      metadata: expect.objectContaining({
+        actorId: 'newstudent@wits.ac.za',
+        actorEmail: 'newstudent@wits.ac.za',
+        studentId: undefined,
+        lecturerId: 'lecturer@wits.ac.za',
+        audienceIds: expect.arrayContaining(['lecturer@wits.ac.za', 'newstudent@wits.ac.za']),
+        audienceEmails: expect.arrayContaining(['lecturer@wits.ac.za', 'newstudent@wits.ac.za'])
+      })
+    }))
+  })
+
+  it('notifies the lecturer when a student joins a session stored under a lecturer number', async () => {
+    Booking.findById.mockResolvedValue({
+      _id: 'booking-2',
+      lecturerId: '2540701',
+      studentId: 'owner@wits.ac.za',
+      date: '2026-06-01',
+      startTime: '10:00',
+      endTime: '11:00',
+      module: 'ELEN50',
+      maxStudents: 10,
+      participantIDs: ['owner@wits.ac.za']
+    })
+    Availability.findOne.mockResolvedValue({
+      weeklySchedule: [
+        {
+          dayOfWeek: 1,
+          slots: [{ start: '10:00', end: '11:00', course: 'ELEN50', maxStudents: 10 }]
+        }
+      ]
+    })
+    Booking.findByIdAndUpdate.mockResolvedValue({})
+    User.find.mockReturnValue({
+      lean: jest.fn().mockResolvedValue([
+        {
+          email: 'newstudent@wits.ac.za',
+          name: 'New',
+          surname: 'Student',
+          role: 'student',
+          emailNotifications: true
+        }
+      ])
+    })
+    User.findOne.mockResolvedValue({
+      email: 'lecturer@wits.ac.za',
+      idNumber: '2540701',
+      name: 'Jane',
+      surname: 'Smith',
+      role: 'lecturer',
+      emailNotifications: true
+    })
+
+    const response = await request(app)
+      .put('/api/bookings/booking-2/join')
+      .send({ email: 'newstudent@wits.ac.za' })
+
+    expect(response.status).toBe(200)
+    expect(sendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'lecturer@wits.ac.za' }),
+      'Student joined your consultation',
+      expect.stringContaining('New Student has joined your consultation.')
+    )
+    expect(User.findOne).toHaveBeenCalledWith({
+      role: 'lecturer',
+      $or: [
+        { email: '2540701' },
+        { idNumber: '2540701' },
+        { idNumber: 2540701 }
+      ]
+    })
   })
 
   it('returns sorted bookings for the requested student', async () => {
@@ -371,9 +470,88 @@ describe('Booking Integration Tests', () => {
     expect(sort).toHaveBeenCalledWith({ date: 1, startTime: 1 })
     expect(lean).toHaveBeenCalled()
     expect(User.find).toHaveBeenCalledWith(
-      { email: { $in: ['lecturer@wits.ac.za'] }, role: 'lecturer' },
-      'name surname email'
+      {
+        role: 'lecturer',
+        $or: [
+          { email: { $in: ['lecturer@wits.ac.za'] } },
+          { idNumber: { $in: ['lecturer@wits.ac.za'] } }
+        ]
+      },
+      'name surname email idNumber'
     )
+  })
+
+  it('returns lecturer names when student bookings store a lecturer id number', async () => {
+    const bookings = [
+      {
+        _id: 'b1',
+        studentId: 'student@wits.ac.za',
+        lecturerId: '2540701',
+        participantIDs: ['student@wits.ac.za'],
+        leftParticipantIDs: [],
+        date: '2026-06-01',
+        startTime: '10:00'
+      }
+    ]
+    const lean = jest.fn().mockResolvedValue(bookings)
+    const sort = jest.fn().mockReturnValue({ lean })
+    Booking.find.mockReturnValue({ sort })
+    User.find.mockReturnValue({
+      lean: jest.fn().mockResolvedValue([
+        { idNumber: '2540701', email: 'lecturer@wits.ac.za', name: 'Jane', surname: 'Smith' }
+      ])
+    })
+
+    const response = await request(app)
+      .get('/api/bookings')
+      .query({ studentId: 'student@wits.ac.za' })
+
+    expect(response.status).toBe(200)
+    expect(response.body).toEqual([
+      { ...bookings[0], lecturerName: 'Jane Smith' }
+    ])
+    expect(User.find).toHaveBeenCalledWith(
+      {
+        role: 'lecturer',
+        $or: [
+          { email: { $in: ['2540701'] } },
+          { idNumber: { $in: ['2540701'] } }
+        ]
+      },
+      'name surname email idNumber'
+    )
+  })
+
+  it('returns a rejoined student booking as active when the student is also in leftParticipantIDs', async () => {
+    const bookings = [
+      {
+        _id: 'b1',
+        studentId: 'owner@wits.ac.za',
+        lecturerId: 'lecturer@wits.ac.za',
+        participantIDs: ['owner@wits.ac.za', 'student@wits.ac.za'],
+        leftParticipantIDs: ['student@wits.ac.za'],
+        date: '2026-06-01',
+        startTime: '10:00',
+        status: 'upcoming'
+      }
+    ]
+    const lean = jest.fn().mockResolvedValue(bookings)
+    const sort = jest.fn().mockReturnValue({ lean })
+    Booking.find.mockReturnValue({ sort })
+    User.find.mockReturnValue({
+      lean: jest.fn().mockResolvedValue([
+        { email: 'lecturer@wits.ac.za', name: 'Jane', surname: 'Smith' }
+      ])
+    })
+
+    const response = await request(app)
+      .get('/api/bookings')
+      .query({ studentId: 'student@wits.ac.za' })
+
+    expect(response.status).toBe(200)
+    expect(response.body).toEqual([
+      { ...bookings[0], lecturerName: 'Jane Smith' }
+    ])
   })
 
   it('returns formatted student names for lecturer bookings', async () => {
@@ -431,6 +609,7 @@ describe('Booking Integration Tests', () => {
     Booking.findById.mockResolvedValue({
       _id: 'session_123',
       studentId: 'student@wits.ac.za',
+      lecturerId: 'lecturer@wits.ac.za',
       module: 'ELEN4010',
       date: '2026-06-01',
       startTime: '10:00',
@@ -448,6 +627,12 @@ describe('Booking Integration Tests', () => {
         }
       ])
     })
+    User.findOne.mockResolvedValue({
+      email: 'lecturer@wits.ac.za',
+      name: 'Jane',
+      role: 'lecturer',
+      emailNotifications: true
+    })
 
     const response = await request(app)
       .delete('/api/bookings/session_123')
@@ -460,6 +645,16 @@ describe('Booking Integration Tests', () => {
       expect.objectContaining({ email: 'student@wits.ac.za' }),
       'Consultation booking canceled',
       expect.stringContaining('Your consultation booking has been canceled.')
+    )
+    expect(sendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'lecturer@wits.ac.za' }),
+      'Student canceled a consultation',
+      expect.stringContaining('Jane has canceled this consultation.')
+    )
+    expect(sendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'lecturer@wits.ac.za' }),
+      'Student canceled a consultation',
+      expect.stringContaining('You can view the updated session from your lecturer dashboard.')
     )
   })
 

--- a/tests/unit/email-service.test.js
+++ b/tests/unit/email-service.test.js
@@ -1,0 +1,168 @@
+describe('emailService', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    jest.resetModules()
+    jest.clearAllMocks()
+    process.env = { ...originalEnv }
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  function loadService ({ nodeEnv = 'test', env = {}, dbReadyState = 0, dbSettings = null } = {}) {
+    process.env.NODE_ENV = nodeEnv
+    Object.assign(process.env, env)
+
+    const appendFileSync = jest.fn()
+    const createTransport = jest.fn().mockReturnValue({
+      sendMail: jest.fn().mockResolvedValue({})
+    })
+    const findOne = jest.fn().mockReturnValue({
+      lean: jest.fn().mockResolvedValue(dbSettings)
+    })
+
+    jest.doMock('fs', () => ({ appendFileSync }))
+    jest.doMock('nodemailer', () => ({ createTransport }))
+    jest.doMock('mongoose', () => ({ connection: { readyState: dbReadyState } }))
+    jest.doMock('../../src/models/emailSettings', () => ({ findOne }))
+
+    return {
+      service: require('../../src/utils/emailService'),
+      appendFileSync,
+      createTransport,
+      findOne
+    }
+  }
+
+  it('suppresses notifications when a user has opted out', async () => {
+    const { service, appendFileSync, createTransport } = loadService()
+
+    await service.sendNotification(
+      { email: 'student@wits.ac.za', emailNotifications: false },
+      'Subject',
+      'Body'
+    )
+
+    expect(appendFileSync).not.toHaveBeenCalled()
+    expect(createTransport).not.toHaveBeenCalled()
+  })
+
+  it('logs simulated email when SMTP is not configured', async () => {
+    const { service, appendFileSync, createTransport } = loadService({ nodeEnv: 'development' })
+
+    await service.sendPasswordResetEmail('student@wits.ac.za', 'https://example.test/reset')
+
+    expect(createTransport).not.toHaveBeenCalled()
+    expect(appendFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('email-log.txt'),
+      expect.stringContaining('TO: student@wits.ac.za | SUBJECT: Consultation Scheduler - Password Reset'),
+      'utf8'
+    )
+  })
+
+  it('sends real mail with environment SMTP configuration outside tests', async () => {
+    const { service, createTransport, appendFileSync } = loadService({
+      nodeEnv: 'development',
+      env: {
+        SMTP_HOST: 'smtp.example.test',
+        SMTP_PORT: '2525',
+        SMTP_SECURE: 'true',
+        SMTP_USER: 'sender@example.test',
+        SMTP_PASS: 'secret',
+        SMTP_FROM: 'no-reply@example.test'
+      }
+    })
+
+    await service.sendNotification(
+      { email: 'lecturer@wits.ac.za', emailNotifications: true },
+      'New booking',
+      'A student booked your slot'
+    )
+
+    expect(createTransport).toHaveBeenCalledWith({
+      host: 'smtp.example.test',
+      port: 2525,
+      secure: true,
+      auth: {
+        user: 'sender@example.test',
+        pass: 'secret'
+      }
+    })
+    expect(createTransport.mock.results[0].value.sendMail).toHaveBeenCalledWith({
+      from: 'no-reply@example.test',
+      to: 'lecturer@wits.ac.za',
+      subject: 'New booking',
+      text: 'A student booked your slot'
+    })
+    expect(appendFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('email-log.txt'),
+      expect.stringContaining('TO: lecturer@wits.ac.za | SUBJECT: New booking'),
+      'utf8'
+    )
+  })
+
+  it('loads enabled SMTP settings from the database when env config is absent', async () => {
+    const { service, createTransport, findOne } = loadService({
+      nodeEnv: 'development',
+      dbReadyState: 1,
+      dbSettings: {
+        service: '',
+        host: 'smtp.db.test',
+        port: 587,
+        secure: false,
+        user: 'db@example.test',
+        pass: 'db-secret',
+        from: 'db-from@example.test'
+      }
+    })
+
+    await service.sendNotification(
+      { email: 'lecturer@wits.ac.za', emailNotifications: true },
+      'Subject',
+      'Body'
+    )
+
+    expect(findOne).toHaveBeenCalledWith({ name: 'default', enabled: true })
+    expect(createTransport).toHaveBeenCalledWith(expect.objectContaining({
+      host: 'smtp.db.test',
+      auth: {
+        user: 'db@example.test',
+        pass: 'db-secret'
+      }
+    }))
+  })
+
+  it('logs failed real email attempts locally', async () => {
+    const { service, createTransport, appendFileSync } = loadService({
+      nodeEnv: 'development',
+      env: {
+        EMAIL_USER: 'sender@gmail.com',
+        EMAIL_PASS: 'secret'
+      }
+    })
+    createTransport.mockReturnValueOnce({
+      sendMail: jest.fn().mockRejectedValue(new Error('SMTP down'))
+    })
+
+    await service.sendNotification(
+      { email: 'lecturer@wits.ac.za', emailNotifications: true },
+      'Subject',
+      'Body'
+    )
+
+    expect(createTransport).toHaveBeenCalledWith({
+      service: 'gmail',
+      auth: {
+        user: 'sender@gmail.com',
+        pass: 'secret'
+      }
+    })
+    expect(appendFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('email-log.txt'),
+      expect.stringContaining('TO: lecturer@wits.ac.za | SUBJECT: Subject'),
+      'utf8'
+    )
+  })
+})

--- a/tests/unit/frontend-pages.test.js
+++ b/tests/unit/frontend-pages.test.js
@@ -128,7 +128,8 @@ describe('Registration page browser script', () => {
         <span id="studnoError"></span>
         <input id="email" />
         <span id="emailError"></span>
-        <select id="role"><option value="student">Student</option><option value="lecturer">Lecturer</option></select>
+        <input type="radio" name="roleOptions" id="roleStudent" value="student" checked />
+        <input type="radio" name="roleOptions" id="roleLecturer" value="lecturer" />
         <input id="password" type="password" />
         <span id="passwordError"></span>
         <input id="confirmPassword" type="password" />
@@ -171,7 +172,7 @@ describe('Registration page browser script', () => {
     document.getElementById('surname').value = 'Doe';
     document.getElementById('idNumber').value = '200001';
     document.getElementById('email').value = 'jane@student.wits.ac.za';
-    document.getElementById('role').value = 'student';
+    document.getElementById('roleStudent').checked = true;
     document.getElementById('password').value = 'SecurePassword123!';
     document.getElementById('confirmPassword').value = 'SecurePassword123!';
     document.getElementById('registrationForm').dispatchEvent(new Event('submit', {

--- a/tests/unit/lecturer-dashboard.test.js
+++ b/tests/unit/lecturer-dashboard.test.js
@@ -47,6 +47,8 @@ beforeEach(() => {
         <input id="search-input" type="text" />
         <div id="schedule-list"></div>
         <div id="empty-state" class="hidden"></div>
+        <button id="menu-toggle"></button>
+        <div id="side-menu" class="hidden"></div>
         <div id="session-modal" class="session-modal-overlay hidden" aria-hidden="true">
             <div id="session-detail-content"></div>
         </div>


### PR DESCRIPTION
## Summary

This PR improves booking visibility, activity-log privacy, dashboard display, and lecturer notifications.

## Changes

## Summary

This PR improves booking visibility, activity-log privacy, dashboard behavior, lecturer notifications, and test coverage.

## Changes

- Fixed student dashboard lecturer display so lecturer names show instead of lecturer/staff numbers.
- Rounded cancel buttons on student and lecturer dashboards.
- Restricted student and lecturer activity logs so users only see activity relevant to them.
- Added activity-log entries when a student joins a session.
- Fixed rejoin behavior after canceling/leaving a joined session:
  - Rejoining removes the student from `leftParticipantIDs`.
  - Rejoined sessions show as active again on the dashboard.
- Added lecturer email notifications for:
  - New bookings on their slots.
  - Students joining their sessions.
  - Students canceling or leaving their slots.
- Improved lecturer lookup by supporting both email and numeric/staff ID identifiers.
- Hardened lecturer dashboard initialization against missing DOM elements.
- Updated registration script to safely support radio-button role controls.
- Added and expanded tests to raise backend coverage above 80%.
