### PR TITLE
feat: add OTP verification and improve dark themed UI

### DIFF
--- a/email-log.txt
+++ b/email-log.txt
@@ -455,3 +455,67 @@ Topic: FF
 
 You can view the updated session from your lecturer dashboard.
 ------------------------------------------------------------------------
+[2026-05-17T15:03:39.008Z] TO: 2357649@students.wits.ac.za | SUBJECT: Consultation Scheduler - Verify your email
+Welcome to Consultation Scheduler.
+
+Your email verification code is: 553095
+
+This code expires in 10 minutes.
+If you did not create an account, you can safely ignore this email.
+------------------------------------------------------------------------
+[2026-05-17T15:03:41.560Z] TO: 2357649@students.wits.ac.za | SUBJECT: Consultation Scheduler - Verify your email
+Welcome to Consultation Scheduler.
+
+Your email verification code is: 518922
+
+This code expires in 10 minutes.
+If you did not create an account, you can safely ignore this email.
+------------------------------------------------------------------------
+[2026-05-17T15:15:16.803Z] TO: 2357649@students.wits.ac.za | SUBJECT: Consultation Scheduler - Password Reset
+You (or someone else) requested a password reset for your account.
+Your password reset OTP is: 588274
+This OTP expires in 1 hour.
+Reset your password here: http://localhost:3000/reset-password.html?email=2357649%40students.wits.ac.za
+If you did not request this, you can safely ignore this email.
+Your password will NOT change until this OTP is entered.
+------------------------------------------------------------------------
+[2026-05-17T15:16:36.028Z] TO: 2357649@students.wits.ac.za | SUBJECT: Your password was changed
+Hi Ngcweti,
+
+Your password was just changed.
+If this wasn’t you, contact support.
+------------------------------------------------------------------------
+[2026-05-17T15:40:14.795Z] TO: mjiyako.ngcweti@gmail.com | SUBJECT: Consultation Scheduler - Verify your email
+Welcome to Consultation Scheduler.
+
+Your email verification code is: 600682
+
+This code expires in 10 minutes.
+If you did not create an account, you can safely ignore this email.
+------------------------------------------------------------------------
+[2026-05-17T15:43:02.466Z] TO: 2357649@students.wits.ac.za | SUBJECT: Consultation booking confirmed
+Hi Ngcweti,
+
+Your consultation booking has been confirmed.
+
+Module: ELEN4010A-SOFTWARE DEVELOPMENT III
+Date: 2026-05-18
+Time: 12:20 - 12:55
+Venue: CM3
+Topic: modals
+
+You can view this booking from your student dashboard.
+------------------------------------------------------------------------
+[2026-05-17T15:43:05.502Z] TO: mjiyako.ngcweti@gmail.com | SUBJECT: New consultation booking
+Hi Babu,
+
+Ngcweti Mjiyako has booked one of your consultation slots.
+
+Module: ELEN4010A-SOFTWARE DEVELOPMENT III
+Date: 2026-05-18
+Time: 12:20 - 12:55
+Venue: CM3
+Topic: modals
+
+You can view this booking from your lecturer dashboard.
+------------------------------------------------------------------------

--- a/public/css/activity-log.css
+++ b/public/css/activity-log.css
@@ -509,31 +509,34 @@ body {
 }
 
 .modal-content {
-    background-color: rgba(255, 255, 255, 0.95);
-    border-radius: 25px;
+    background: rgba(25, 25, 35, 0.97);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 20px;
     width: 90%;
     max-width: 520px;
     max-height: 80vh;
     overflow-y: auto;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6);
 }
 
 .modal-header {
     padding: 20px 25px;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
     display: flex;
     justify-content: space-between;
     align-items: center;
     position: sticky;
     top: 0;
-    background: white;
-    border-radius: 25px 25px 0 0;
+    background: rgba(25, 25, 35, 0.98);
+    border-radius: 20px 20px 0 0;
 }
 
 .modal-header h2 {
     font-size: 20px;
     margin: 0;
-    color: #333;
+    color: white;
     font-weight: 600;
 }
 
@@ -542,13 +545,13 @@ body {
     border: none;
     font-size: 24px;
     cursor: pointer;
-    color: #888888;
+    color: rgba(255, 255, 255, 0.55);
     padding: 5px;
     line-height: 1;
 }
 
 .close-btn:hover {
-    color: #333;
+    color: white;
 }
 
 .detail-body {
@@ -559,17 +562,17 @@ body {
     display: flex;
     justify-content: space-between;
     padding: 12px 0;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .detail-label {
     font-weight: 600;
-    color: #333;
+    color: rgba(255, 255, 255, 0.72);
     font-size: 14px;
 }
 
 .detail-value {
-    color: #555;
+    color: white;
     font-size: 14px;
     text-align: right;
     max-width: 60%;
@@ -579,10 +582,11 @@ body {
 .detail-value pre {
     margin: 0;
     font-size: 12px;
-    background: #f5f5f5;
+    background: rgba(255, 255, 255, 0.08);
     padding: 8px;
     border-radius: 10px;
     text-align: left;
+    color: white;
 }
 
 /* Auto-refresh active state */

--- a/public/css/lecturer-availability.css
+++ b/public/css/lecturer-availability.css
@@ -76,12 +76,12 @@ body {
     right: 0;
     top: 100%;
     margin-top: 8px;
-    background: rgba(255, 255, 255, 0.95);
+    background: rgba(25, 25, 35, 0.97);
     backdrop-filter: blur(10px);
     border-radius: 15px;
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.14);
     min-width: 180px;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.55);
     z-index: 1000;
     overflow: hidden;
 }
@@ -95,7 +95,7 @@ body {
     align-items: center;
     gap: 10px;
     padding: 12px 20px;
-    color: #333;
+    color: rgba(255, 255, 255, 0.88);
     text-decoration: none;
     font-size: 14px;
     font-weight: 500;
@@ -109,12 +109,12 @@ body {
 }
 
 .dropdown_item:hover {
-    background: rgba(255, 193, 7, 0.1);
+    background: rgba(255, 193, 7, 0.14);
 }
 
 .dropdown_divider {
     height: 1px;
-    background: rgba(0, 0, 0, 0.1);
+    background: rgba(255, 255, 255, 0.1);
     margin: 4px 0;
 }
 

--- a/public/css/lecturer-dashboard.css
+++ b/public/css/lecturer-dashboard.css
@@ -39,10 +39,14 @@ body {
     top: 55px;
     left: 0;
     width: 220px;
-    background: white;
-    border-radius: 10px;
-    box-shadow: 0 10px 25px rgba(0,0,0,0.1);
+    background: rgba(25, 25, 35, 0.97);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 14px;
+    box-shadow: 0 16px 48px rgba(0,0,0,0.55);
     z-index: 1000; 
+    overflow: hidden;
 }
 
 .burger-dropdown.hidden {
@@ -55,23 +59,22 @@ body {
     gap: 12px;
     padding: 12px 16px;
     text-decoration: none;
-    color: #475569;
+    color: rgba(255, 255, 255, 0.88);
     font-size: 0.95rem;
 }
 
 .menu-items a:hover {
-    background: #f1f5f9;
-    border-radius: 10px;
+    background: rgba(255, 193, 7, 0.14);
 }
 
 .menu-items hr {
     margin: 5px 0;
     border: 0;
-    border-top: 1px solid #e2e8f0;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .sign-out {
-    color: #dc2626 !important;
+    color: #ff6b6b !important;
 }
 
 .date-banner {
@@ -520,31 +523,34 @@ body.session-modal-open {
 }
 
 .session-modal-panel {
-    background-color: rgba(255, 255, 255, 0.95);
-    border-radius: 25px;
+    background: rgba(25, 25, 35, 0.97);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 20px;
     width: 90%;
     max-width: 500px;
     max-height: 80vh;
     overflow-y: auto;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6);
 }
 
 .session-modal-header {
     padding: 20px 25px;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
     display: flex;
     justify-content: space-between;
     align-items: center;
     position: sticky;
     top: 0;
-    background: white;
-    border-radius: 25px 25px 0 0;
+    background: rgba(25, 25, 35, 0.98);
+    border-radius: 20px 20px 0 0;
 }
 
 .session-modal-header h2 {
     font-size: 20px;
     margin: 0;
-    color: #333;
+    color: white;
 }
 
 .close-btn {
@@ -552,11 +558,11 @@ body.session-modal-open {
     border: none;
     font-size: 24px;
     cursor: pointer;
-    color: #888888;
+    color: rgba(255, 255, 255, 0.55);
 }
 
 .close-btn:hover {
-    color: #333;
+    color: white;
 }
 
 .detail-body {
@@ -567,17 +573,17 @@ body.session-modal-open {
     display: flex;
     justify-content: space-between;
     padding: 12px 0;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .detail-label {
     font-weight: 600;
-    color: #333;
+    color: rgba(255, 255, 255, 0.72);
     font-size: 14px;
 }
 
 .detail-value {
-    color: #555;
+    color: white;
     font-size: 14px;
     text-align: right;
 }
@@ -588,7 +594,7 @@ body.session-modal-open {
 
 .detail-students h4 {
     font-size: 14px;
-    color: #333;
+    color: white;
     margin-bottom: 10px;
 }
 
@@ -602,7 +608,7 @@ body.session-modal-open {
     justify-content: space-between;
     gap: 10px;
     padding: 0 0 6px;
-    color: #333;
+    color: rgba(255, 255, 255, 0.72);
     font-size: 13px;
     font-weight: 600;
 }
@@ -619,8 +625,8 @@ body.session-modal-open {
     justify-content: space-between;
     gap: 10px;
     font-size: 14px;
-    color: #555;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.04);
+    color: white;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .student-list-name {
@@ -632,10 +638,14 @@ body.session-modal-open {
 }
 
 .student-list-topic {
-    color: #555;
+    color: rgba(255, 255, 255, 0.72);
     max-width: 45%;
     text-align: right;
     overflow-wrap: anywhere;
+}
+
+.detail-students p {
+    color: rgba(255, 255, 255, 0.6) !important;
 }
 
 /* Responsive */

--- a/public/css/login-page.css
+++ b/public/css/login-page.css
@@ -5,6 +5,39 @@ body {
     background-repeat: no-repeat;
     background-attachment: fixed;
     font-family: 'Inter', sans-serif;
+    min-height: 100vh;
+    margin: 0;
+}
+
+.auth-wrapper {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    width: 100%;
+}
+
+.login_background {
+    background-color: rgba(10, 21, 38, 0.72);
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 18px;
+}
+
+.logo_image {
+    max-width: min(72vw, 420px);
+    height: auto;
+}
+
+.welcome_text {
+    color: rgba(255, 255, 255, 0.72);
+    margin: 0;
+}
+
+.login_text {
+    color: #fff;
+    font-weight: 700;
+    text-align: center;
 }
 
 .login-card {
@@ -34,4 +67,74 @@ body {
 
 .btn-warning:hover {
     background-color: #e0a800;
+}
+
+.input_container {
+    position: relative;
+    margin-bottom: 14px;
+}
+
+.input_icon {
+    position: absolute;
+    left: 13px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #6c757d;
+    font-size: 20px;
+    z-index: 1;
+}
+
+.toggle_link {
+    position: absolute;
+    right: 13px;
+    top: 50%;
+    transform: translateY(-50%);
+    cursor: pointer;
+    color: #212529;
+    font-size: 20px;
+}
+
+.text_entry_field {
+    width: 100%;
+    height: 42px;
+    border: 0;
+    border-radius: 12px;
+    padding: 0 42px;
+    background: #fff;
+    color: #212529;
+}
+
+.login_button {
+    width: 100%;
+    min-height: 43px;
+    border: 0;
+    border-radius: 999px;
+    background: #FFC107;
+    color: #111;
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.login_button:hover {
+    background: #e0a800;
+}
+
+.inline_error {
+    display: block;
+    min-height: 18px;
+    color: #ff8a8a;
+    font-size: 12px;
+    margin-top: -8px;
+    margin-bottom: 8px;
+}
+
+.new_account_text-2,
+.designer_info {
+    color: rgba(255, 255, 255, 0.72);
+}
+
+.new_account_text {
+    color: #FFC107;
+    font-weight: 600;
+    text-decoration: none;
 }

--- a/public/css/register-page.css
+++ b/public/css/register-page.css
@@ -5,12 +5,55 @@ body {
     background-repeat: no-repeat !important;
     background-attachment: fixed !important;
     font-family: 'Inter', sans-serif;
+    min-height: 100vh;
 }
 
 .register-card {
-    background-color: rgba(255, 255, 255, 0.2) !important;
+    background-color: rgba(10, 21, 38, 0.82) !important;
     backdrop-filter: blur(10px);
-    border-radius: 25px;
+    border: 1px solid rgba(255, 255, 255, 0.14) !important;
+    border-radius: 16px !important;
+    color: #fff;
+}
+
+.register-card .card-body {
+    padding: 2rem !important;
+}
+
+.register-card .form-control,
+.register-card .input-group-text {
+    min-height: 48px;
+    border-color: rgba(255, 255, 255, 0.85);
+    background-color: #fff;
+    color: #20242a;
+    font-size: 1rem;
+}
+
+.register-card .form-control::placeholder {
+    color: #5f646b;
+}
+
+.register-card .form-control.rounded-pill,
+.register-card .btn-group.rounded-pill {
+    border-radius: 16px !important;
+}
+
+.register-card .btn.rounded-pill,
+.register-card .btn-warning.rounded-pill {
+    border-radius: 999px !important;
+}
+
+.register-card .btn-warning {
+    min-height: 48px;
+    color: #080808;
+}
+
+.register-card .btn-outline-light {
+    border-color: rgba(255, 255, 255, 0.72);
+}
+
+.register-card .text-danger {
+    color: #ff9b9b !important;
 }
 
 .btn-check:checked + .btn-outline-primary {
@@ -20,8 +63,20 @@ body {
 }
 
 .btn-outline-primary {
-    color: #555;
+    color: #4c535b;
     transition: all 0.3s ease;
+}
+
+#role {
+    background-color: #fff !important;
+    border-radius: 999px !important;
+}
+
+#role .btn {
+    min-height: 42px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .x-small {
@@ -29,11 +84,11 @@ body {
 }
 
 .rounded-start-pill {
-    border-top-left-radius: 50rem !important;
-    border-bottom-left-radius: 50rem !important;
+    border-top-left-radius: 16px !important;
+    border-bottom-left-radius: 16px !important;
 }
 
 .rounded-end-pill {
-    border-top-right-radius: 50rem !important;
-    border-bottom-right-radius: 50rem !important;
+    border-top-right-radius: 16px !important;
+    border-bottom-right-radius: 16px !important;
 }

--- a/public/css/student-dashboard.css
+++ b/public/css/student-dashboard.css
@@ -43,10 +43,14 @@ body {
     top: 55px;
     left: 0;
     width: 220px;
-    background: white;
-    border-radius: 10px;
-    box-shadow: 0 10px 25px rgba(0,0,0,0.1);
+    background: rgba(25, 25, 35, 0.97);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 14px;
+    box-shadow: 0 16px 48px rgba(0,0,0,0.55);
     z-index: 1000; 
+    overflow: hidden;
 }
 
 .burger-dropdown.hidden {
@@ -59,23 +63,22 @@ body {
     gap: 12px;
     padding: 12px 16px;
     text-decoration: none;
-    color: #475569;
+    color: rgba(255, 255, 255, 0.88);
     font-size: 0.95rem;
 }
 
 .menu-items a:hover {
-    background: #f1f5f9;
-    border-radius: 10px;
+    background: rgba(255, 193, 7, 0.14);
 }
 
 .menu-items hr {
     margin: 5px 0;
     border: 0;
-    border-top: 1px solid #e2e8f0;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .sign-out {
-    color: #dc2626 !important;
+    color: #ff6b6b !important;
 }
 
 .schedule-container {
@@ -519,31 +522,34 @@ body {
 }
 
 .modal-content {
-    background-color: rgba(255, 255, 255, 0.95);
-    border-radius: 25px;
+    background: rgba(25, 25, 35, 0.97);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 20px;
     width: 90%;
     max-width: 500px;
     max-height: 80vh;
     overflow-y: auto;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6);
 }
 
 .modal-header {
     padding: 20px 25px;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
     display: flex;
     justify-content: space-between;
     align-items: center;
     position: sticky;
     top: 0;
-    background: white;
-    border-radius: 25px 25px 0 0;
+    background: rgba(25, 25, 35, 0.98);
+    border-radius: 20px 20px 0 0;
 }
 
 .modal-header h2 {
     font-size: 20px;
     margin: 0;
-    color: #333;
+    color: white;
 }
 
 .close-btn {
@@ -551,11 +557,11 @@ body {
     border: none;
     font-size: 24px;
     cursor: pointer;
-    color: #888888;
+    color: rgba(255, 255, 255, 0.55);
 }
 
 .close-btn:hover {
-    color: #333;
+    color: white;
 }
 
 .detail-body {
@@ -566,17 +572,17 @@ body {
     display: flex;
     justify-content: space-between;
     padding: 12px 0;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .detail-label {
     font-weight: 600;
-    color: #333;
+    color: rgba(255, 255, 255, 0.72);
     font-size: 14px;
 }
 
 .detail-value {
-    color: #555;
+    color: white;
     font-size: 14px;
     text-align: right;
 }
@@ -587,7 +593,7 @@ body {
 
 .detail-students h4 {
     font-size: 14px;
-    color: #333;
+    color: white;
     margin-bottom: 10px;
 }
 
@@ -602,8 +608,8 @@ body {
     align-items: center;
     gap: 10px;
     font-size: 14px;
-    color: #555;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.04);
+    color: white;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .bottom-actions {

--- a/public/forgot-password.html
+++ b/public/forgot-password.html
@@ -4,51 +4,68 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Forgot Password - Consultation Scheduler</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
     <link rel="stylesheet" href="css/login-page.css">
     <link rel="stylesheet" href="css/password-pages.css">
 </head>
 <body>
-    <div class="auth-wrapper">
-        <div>
-            <h2 class="logo"><img src="images/synchro-logo.png" alt="Synchro Logo" class="logo_image"></h2>
-            <p class="welcome_text">Password recovery</p>
+    <div class="auth-wrapper py-5">
+        <div class="text-center mb-4">
+            <h2 class="logo">
+                <img src="images/synchro-logo.png" alt="Synchro Logo" class="logo_image" style="max-height: 80px;">
+            </h2>
+            <p class="welcome_text text-white-50">Password recovery</p>
         </div>
-        <form id="forgotForm" novalidate>
-            <div class="login_background">
-                <a class="back_link" href="login-page.html">
-                    <span class="material-symbols-outlined">arrow_back</span> Back to login
-                </a>
-                <h2 class="login_text">FORGOT PASSWORD</h2>
 
+        <div class="login_background mx-auto p-4 rounded shadow-lg" style="max-width: 450px;">
+            <a class="back_link" href="login-page.html">
+                <span class="material-symbols-outlined">arrow_back</span> Back to login
+            </a>
+            <h2 class="h4 text-center text-white mb-4 fw-bold">FORGOT PASSWORD</h2>
+
+            <form id="forgotForm" novalidate>
                 <div id="formContent">
-                    <p class="info_text">Enter the email address linked to your account and we'll send you a reset link.</p>
-                    <div class="input_container">
-                        <span class="material-symbols-outlined input_icon">mail</span>
-                        <input class="text_entry_field" type="email" id="email" placeholder="Email Address" required>
+                    <p class="info_text mb-3">Enter the email address linked to your account and we'll send you a reset OTP.</p>
+
+                    <div class="mb-3">
+                        <div class="input-group">
+                            <span class="input-group-text bg-white border-end-0">
+                                <span class="material-symbols-outlined text-secondary">mail</span>
+                            </span>
+                            <input class="form-control border-start-0 ps-0" type="email" id="email" placeholder="Email Address" required>
+                        </div>
+                        <span id="emailError" class="text-danger small d-block mt-1"></span>
                     </div>
-                    <span id="emailError" class="inline_error"></span>
-                    <button class="login_button" type="submit" id="submitBtn">Send Reset Link</button>
+
+                    <div class="d-grid mb-3">
+                        <button class="btn btn-warning fw-bold rounded-pill" type="submit" id="submitBtn" style="height: 45px;">Send Reset OTP</button>
+                    </div>
                 </div>
 
                 <div class="success_box" id="successBox">
                     <span class="material-symbols-outlined success_icon">mark_email_read</span>
                     <p class="success_title">Check your email</p>
-                    <p class="success_subtitle">If that address is registered, a reset link has been sent. Check your inbox (and spam folder).</p>
-                    <button class="btn_secondary" onclick="window.location='login-page.html'">Return to Login</button>
+                    <p class="success_subtitle" id="successMessage">If that address is registered, a reset OTP has been sent. Check your inbox (and spam folder).</p>
+                    <button class="btn_secondary" type="button" id="continueBtn">Enter OTP</button>
                 </div>
 
-                <div class="new_account_placeholder" id="registerLink">
-                    <p class="new_account_text-2">Don't have an account? <a class="new_account_text" href="register-page.html">Create a new account.</a></p>
+                <div class="text-center" id="registerLink">
+                    <p class="text-white small mb-0">Don't have an account? <a class="text-warning text-decoration-none fw-semibold" href="register-page.html">Create a new account.</a></p>
                 </div>
-            </div>
-            <div class="designer_info">Designed by students at the University of the Witwatersrand</div>
-        </form>
+            </form>
+        </div>
+
+        <div class="text-center mt-5">
+            <small class="text-white-50">Designed by students at the University of the Witwatersrand</small>
+        </div>
+
         <script>
             const $ = id => document.getElementById(id)
             const form = $('forgotForm'), emailEl = $('email'), emailErr = $('emailError')
             const submitBtn = $('submitBtn'), formContent = $('formContent')
             const successBox = $('successBox'), registerLink = $('registerLink')
+            const successMessage = $('successMessage'), continueBtn = $('continueBtn')
 
             form.addEventListener('submit', async (e) => {
                 e.preventDefault()
@@ -57,24 +74,27 @@
                 if (!email) { emailErr.textContent = 'Please enter your email address.'; return }
                 if (!/\S+@\S+\.\S+/.test(email)) { emailErr.textContent = 'Please enter a valid email address.'; return }
                 submitBtn.disabled = true
-                submitBtn.textContent = 'Sending…'
+                submitBtn.textContent = 'Sending...'
                 try {
                     const data = await fetch('/api/auth/forgot-password', {
                         method: 'POST', headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({ email })
                     }).then(r => r.json())
                     if (data.success) {
+                        const devOtpMessage = data.devOtp ? ` Local development OTP: ${data.devOtp}` : ''
+                        successMessage.textContent = `${data.message || 'If that address is registered, a reset OTP has been sent.'}${devOtpMessage}`
+                        continueBtn.onclick = () => { window.location = `reset-password.html?email=${encodeURIComponent(email)}` }
                         formContent.style.display = registerLink.style.display = 'none'
                         successBox.style.display = 'flex'
                     } else {
                         emailErr.textContent = data.error || 'Something went wrong. Please try again.'
                         submitBtn.disabled = false
-                        submitBtn.textContent = 'Send Reset Link'
+                        submitBtn.textContent = 'Send Reset OTP'
                     }
                 } catch {
                     emailErr.textContent = 'Network error. Please check your connection.'
                     submitBtn.disabled = false
-                    submitBtn.textContent = 'Send Reset Link'
+                    submitBtn.textContent = 'Send Reset OTP'
                 }
             })
         </script>

--- a/public/js/register-page.js
+++ b/public/js/register-page.js
@@ -138,8 +138,9 @@ registrationForm.addEventListener('submit', async (event) => {
     const result = await response.json()
 
     if (response.ok && result.success) {
-      alert('Welcome to Synchro! Redirecting to login...')
-      window.location.href = 'login-page.html'
+      const devOtpMessage = result.devOtp ? `\n\nLocal development OTP: ${result.devOtp}` : ''
+      alert(`Welcome to Synchro! Please verify your email with the OTP we sent.${devOtpMessage}`)
+      window.location.href = `verify-email.html?email=${encodeURIComponent(formData.email)}`
     } else {
       // Show server-side error (e.g., "Email already exists")
       errorMessage.textContent = result.error || 'Registration failed.'

--- a/public/js/verify-email.js
+++ b/public/js/verify-email.js
@@ -1,0 +1,69 @@
+const params = new URLSearchParams(window.location.search)
+const emailInput = document.getElementById('email')
+const otpInput = document.getElementById('otp')
+const messageEl = document.getElementById('verification-message')
+const form = document.getElementById('verifyEmailForm')
+const resendBtn = document.getElementById('resendOtpBtn')
+
+if (emailInput && params.get('email')) {
+  emailInput.value = params.get('email')
+}
+
+function showMessage (message, isError = true) {
+  messageEl.textContent = message
+  messageEl.classList.toggle('text-danger', isError)
+  messageEl.classList.toggle('text-success', !isError)
+}
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault()
+
+  const email = emailInput.value.trim()
+  const otp = otpInput.value.trim()
+  if (!email || !otp) {
+    showMessage('Please enter your email and OTP.')
+    return
+  }
+
+  try {
+    const response = await fetch('/api/auth/verify-email', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, otp })
+    })
+    const result = await response.json()
+
+    if (!response.ok || !result.success) {
+      showMessage(result.error || 'Invalid or expired OTP.')
+      return
+    }
+
+    showMessage('Email verified. Redirecting to login...', false)
+    setTimeout(() => {
+      window.location.href = 'login-page.html'
+    }, 800)
+  } catch (error) {
+    showMessage('Unable to verify right now. Please try again.')
+  }
+})
+
+resendBtn.addEventListener('click', async () => {
+  const email = emailInput.value.trim()
+  if (!email) {
+    showMessage('Please enter your email first.')
+    return
+  }
+
+  try {
+    const response = await fetch('/api/auth/resend-verification', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email })
+    })
+    const result = await response.json()
+    const devOtpMessage = result.devOtp ? ` Local development OTP: ${result.devOtp}` : ''
+    showMessage(`${result.message || 'If verification is needed, a new OTP has been sent.'}${devOtpMessage}`, !response.ok)
+  } catch (error) {
+    showMessage('Unable to resend OTP right now. Please try again.')
+  }
+})

--- a/public/reset-password.html
+++ b/public/reset-password.html
@@ -4,132 +4,180 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Reset Password - Consultation Scheduler</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
     <link rel="stylesheet" href="css/login-page.css">
     <link rel="stylesheet" href="css/password-pages.css">
 </head>
 <body>
-    <div class="auth-wrapper">
-        <div>
-            <h2 class="logo"><img src="images/synchro-logo.png" alt="Synchro Logo" class="logo_image"></h2>
-            <p class="welcome_text">Set a new password</p>
+    <div class="auth-wrapper py-5">
+        <div class="text-center mb-4">
+            <h2 class="logo">
+                <img src="images/synchro-logo.png" alt="Synchro Logo" class="logo_image" style="max-height: 80px;">
+            </h2>
+            <p class="welcome_text text-white-50">Set a new password</p>
         </div>
-        <form id="resetForm" novalidate>
-            <div class="login_background">
-                <h2 class="login_text">RESET PASSWORD</h2>
 
+        <div class="login_background mx-auto p-4 rounded shadow-lg" style="max-width: 450px;">
+            <a class="back_link" href="forgot-password.html">
+                <span class="material-symbols-outlined">arrow_back</span> Request new OTP
+            </a>
+            <h2 class="h4 text-center text-white mb-4 fw-bold">RESET PASSWORD</h2>
+
+            <form id="resetForm" novalidate>
                 <div class="invalid_box" id="invalidBox">
-                    <span class="material-symbols-outlined invalid_icon">link_off</span>
-                    <p class="invalid_title">Link invalid or expired</p>
-                    <p class="invalid_subtitle">This reset link has already been used or has expired. Please request a new one.</p>
-                    <button class="login_button" type="button" onclick="window.location='forgot-password.html'" style="margin-top:8px">Request New Link</button>
+                    <span class="material-symbols-outlined invalid_icon">error</span>
+                    <p class="invalid_title">OTP invalid or expired</p>
+                    <p class="invalid_subtitle">This reset OTP has already been used or has expired. Please request a new one.</p>
+                    <button class="btn btn-warning fw-bold rounded-pill w-100" type="button" onclick="window.location='forgot-password.html'" style="height:45px">Request New OTP</button>
                 </div>
 
                 <div id="formContent">
-                    <div class="input_container">
-                        <span class="material-symbols-outlined input_icon">lock</span>
-                        <input class="text_entry_field" type="password" id="newPassword" placeholder="New Password" required>
-                        <span id="togglePassword1" class="material-symbols-outlined toggle_link">visibility</span>
+                    <div class="mb-3">
+                        <div class="input-group">
+                            <span class="input-group-text bg-white border-end-0">
+                                <span class="material-symbols-outlined text-secondary">mail</span>
+                            </span>
+                            <input class="form-control border-start-0 ps-0" type="email" id="email" placeholder="Email Address" required>
+                        </div>
                     </div>
-                    <div class="strength_bar_wrap">
+
+                    <div class="mb-3">
+                        <div class="input-group">
+                            <span class="input-group-text bg-white border-end-0">
+                                <span class="material-symbols-outlined text-secondary">pin</span>
+                            </span>
+                            <input class="form-control border-start-0 ps-0" type="text" id="otp" placeholder="Reset OTP" inputmode="numeric" maxlength="6" required>
+                        </div>
+                    </div>
+
+                    <div class="mb-2">
+                        <div class="input-group">
+                            <span class="input-group-text bg-white border-end-0">
+                                <span class="material-symbols-outlined text-secondary">lock</span>
+                            </span>
+                            <input class="form-control border-start-0 border-end-0 ps-0" type="password" id="newPassword" placeholder="New Password" required>
+                            <span class="input-group-text bg-white border-start-0" style="cursor: pointer;">
+                                <span id="togglePassword1" class="material-symbols-outlined text-dark">visibility</span>
+                            </span>
+                        </div>
+                    </div>
+
+                    <div class="strength_bar_wrap mb-1">
                         <div class="strength_seg" id="seg1"></div>
                         <div class="strength_seg" id="seg2"></div>
                         <div class="strength_seg" id="seg3"></div>
                         <div class="strength_seg" id="seg4"></div>
                     </div>
-                    <span class="strength_label" id="strengthLabel"></span>
-                    <div class="input_container">
-                        <span class="material-symbols-outlined input_icon">lock_reset</span>
-                        <input class="text_entry_field" type="password" id="confirmPassword" placeholder="Confirm Password" required>
-                        <span id="togglePassword2" class="material-symbols-outlined toggle_link">visibility</span>
+                    <span class="strength_label d-block mb-2" id="strengthLabel"></span>
+
+                    <div class="mb-3">
+                        <div class="input-group">
+                            <span class="input-group-text bg-white border-end-0">
+                                <span class="material-symbols-outlined text-secondary">lock_reset</span>
+                            </span>
+                            <input class="form-control border-start-0 border-end-0 ps-0" type="password" id="confirmPassword" placeholder="Confirm Password" required>
+                            <span class="input-group-text bg-white border-start-0" style="cursor: pointer;">
+                                <span id="togglePassword2" class="material-symbols-outlined text-dark">visibility</span>
+                            </span>
+                        </div>
                     </div>
-                    <span id="formError" class="inline_error"></span>
-                    <button class="login_button" type="submit" id="submitBtn">Set New Password</button>
+
+                    <span id="formError" class="text-danger small d-block mb-3"></span>
+
+                    <div class="d-grid mb-3">
+                        <button class="btn btn-warning fw-bold rounded-pill" type="submit" id="submitBtn" style="height:45px">Set New Password</button>
+                    </div>
                 </div>
 
                 <div class="success_box" id="successBox">
                     <span class="material-symbols-outlined success_icon">check_circle</span>
                     <p class="success_title">Password updated!</p>
                     <p class="success_subtitle">Your password has been changed successfully. You can now log in.</p>
-                    <button class="login_button" type="button" onclick="window.location='login-page.html'" style="margin-top:8px">Go to Login</button>
+                    <button class="btn btn-warning fw-bold rounded-pill w-100" type="button" onclick="window.location='login-page.html'" style="height:45px">Go to Login</button>
                 </div>
 
-                <div class="new_account_placeholder" id="loginLink">
-                    <p class="new_account_text-2">Remembered your password? <a class="new_account_text" href="login-page.html">Login here.</a></p>
+                <div class="text-center" id="loginLink">
+                    <p class="text-white small mb-0">Remembered your password? <a class="text-warning text-decoration-none fw-semibold" href="login-page.html">Login here.</a></p>
                 </div>
-            </div>
-            <div class="designer_info">Designed by students at the University of the Witwatersrand</div>
-        </form>
-        <script>
-        (function () {
-            const $ = id => document.getElementById(id)
-            const params = new URLSearchParams(window.location.search)
-            const token = params.get('token'), email = params.get('email')
-            const formContent = $('formContent'), invalidBox = $('invalidBox')
-            const successBox = $('successBox'), loginLink = $('loginLink')
-            const formError = $('formError'), submitBtn = $('submitBtn')
+            </form>
+        </div>
 
-            if (!token || !email) {
-                formContent.style.display = 'none'
-                invalidBox.style.display = 'flex'
-            }
+        <div class="text-center mt-5">
+            <small class="text-white-50">Designed by students at the University of the Witwatersrand</small>
+        </div>
+    </div>
 
-            // Visibility toggles
-            function setupToggle(toggleId, inputId) {
-                $(toggleId).addEventListener('click', function () {
-                    const inp = $(inputId), hidden = inp.type === 'password'
-                    inp.type = hidden ? 'text' : 'password'
-                    this.textContent = hidden ? 'visibility_off' : 'visibility'
-                })
-            }
-            setupToggle('togglePassword1', 'newPassword')
-            setupToggle('togglePassword2', 'confirmPassword')
+    <script>
+    (function () {
+        const $ = id => document.getElementById(id)
+        const params = new URLSearchParams(window.location.search)
+        const email = params.get('email')
+        const formContent = $('formContent'), invalidBox = $('invalidBox')
+        const successBox = $('successBox'), loginLink = $('loginLink')
+        const formError = $('formError'), submitBtn = $('submitBtn')
 
-            // Strength meter
-            const segs = [1,2,3,4].map(n => $('seg'+n))
-            const COLORS = ['#ff4d4d', '#ffa500', '#FFC107', '#4caf50']
-            const LABELS = ['', 'Weak', 'Fair', 'Good', 'Strong']
-            const calcStrength = pw => [pw.length >= 8, /[A-Z]/.test(pw), /[0-9]/.test(pw), /[^A-Za-z0-9]/.test(pw)].filter(Boolean).length
+        if (email) {
+            $('email').value = email
+        }
 
-            $('newPassword').addEventListener('input', function () {
-                const score = calcStrength(this.value)
-                segs.forEach((s, i) => s.style.background = i < score ? COLORS[score - 1] : 'rgba(255,255,255,0.2)')
-                $('strengthLabel').textContent = this.value ? LABELS[score] : ''
+        function setupToggle (toggleId, inputId) {
+            $(toggleId).addEventListener('click', function () {
+                const inp = $(inputId), hidden = inp.type === 'password'
+                inp.type = hidden ? 'text' : 'password'
+                this.textContent = hidden ? 'visibility_off' : 'visibility'
             })
+        }
+        setupToggle('togglePassword1', 'newPassword')
+        setupToggle('togglePassword2', 'confirmPassword')
 
-            // Form submission
-            $('resetForm').addEventListener('submit', async (e) => {
-                e.preventDefault()
-                formError.textContent = ''
-                const newPassword = $('newPassword').value, confirmPassword = $('confirmPassword').value
-                if (newPassword.length < 8) { formError.textContent = 'Password must be at least 8 characters.'; return }
-                if (newPassword !== confirmPassword) { formError.textContent = 'Passwords do not match.'; return }
-                submitBtn.disabled = true
-                submitBtn.textContent = 'Updating…'
-                try {
-                    const data = await fetch('/api/auth/reset-password', {
-                        method: 'POST', headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ email, token, newPassword })
-                    }).then(r => r.json())
-                    if (data.success) {
-                        formContent.style.display = loginLink.style.display = 'none'
-                        successBox.style.display = 'flex'
-                    } else if (data.error?.toLowerCase().includes('expired')) {
-                        formContent.style.display = 'none'
-                        invalidBox.style.display = 'flex'
-                    } else {
-                        formError.textContent = data.error || 'Something went wrong.'
-                        submitBtn.disabled = false
-                        submitBtn.textContent = 'Set New Password'
-                    }
-                } catch {
-                    formError.textContent = 'Network error. Please check your connection.'
+        const segs = [1, 2, 3, 4].map(n => $('seg' + n))
+        const COLORS = ['#ff4d4d', '#ffa500', '#FFC107', '#4caf50']
+        const LABELS = ['', 'Weak', 'Fair', 'Good', 'Strong']
+        const calcStrength = pw => [pw.length >= 8, /[A-Z]/.test(pw), /[0-9]/.test(pw), /[^A-Za-z0-9]/.test(pw)].filter(Boolean).length
+
+        $('newPassword').addEventListener('input', function () {
+            const score = calcStrength(this.value)
+            segs.forEach((s, i) => { s.style.background = i < score ? COLORS[score - 1] : 'rgba(255,255,255,0.2)' })
+            $('strengthLabel').textContent = this.value ? LABELS[score] : ''
+        })
+
+        $('resetForm').addEventListener('submit', async (e) => {
+            e.preventDefault()
+            formError.textContent = ''
+            const emailValue = $('email').value.trim()
+            const otp = $('otp').value.trim()
+            const newPassword = $('newPassword').value, confirmPassword = $('confirmPassword').value
+            if (!emailValue) { formError.textContent = 'Please enter your email address.'; return }
+            if (!otp) { formError.textContent = 'Please enter the reset OTP.'; return }
+            if (newPassword.length < 8) { formError.textContent = 'Password must be at least 8 characters.'; return }
+            if (newPassword !== confirmPassword) { formError.textContent = 'Passwords do not match.'; return }
+            submitBtn.disabled = true
+            submitBtn.textContent = 'Updating...'
+            try {
+                const data = await fetch('/api/auth/reset-password', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ email: emailValue, otp, newPassword })
+                }).then(r => r.json())
+                if (data.success) {
+                    formContent.style.display = loginLink.style.display = 'none'
+                    successBox.style.display = 'flex'
+                } else if (data.error?.toLowerCase().includes('expired')) {
+                    formContent.style.display = 'none'
+                    invalidBox.style.display = 'flex'
+                } else {
+                    formError.textContent = data.error || 'Something went wrong.'
                     submitBtn.disabled = false
                     submitBtn.textContent = 'Set New Password'
                 }
-            })
-        })()
-        </script>
-    </div>
+            } catch {
+                formError.textContent = 'Network error. Please check your connection.'
+                submitBtn.disabled = false
+                submitBtn.textContent = 'Set New Password'
+            }
+        })
+    })()
+    </script>
 </body>
 </html>

--- a/public/verify-email.html
+++ b/public/verify-email.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Verify Email | Consultation Scheduler</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="css/register-page.css">
+</head>
+<body>
+    <div class="container d-flex justify-content-center align-items-center min-vh-100 py-4">
+        <div class="auth-wrapper w-100" style="max-width: 450px;">
+            <div class="text-center mb-4">
+                <h1 class="text-white fw-bold h2">Verify Your Email</h1>
+            </div>
+
+            <div class="card register-card border-0 shadow-lg">
+                <div class="card-body p-4">
+                    <form id="verifyEmailForm" novalidate>
+                        <div class="mb-3">
+                            <input type="email" class="form-control rounded-pill" id="email" placeholder="Email Address" required>
+                        </div>
+                        <div class="mb-3">
+                            <input type="text" class="form-control rounded-pill text-center" id="otp" placeholder="6-digit OTP" maxlength="6" required>
+                        </div>
+                        <span id="verification-message" class="text-danger small d-block text-center mb-3"></span>
+                        <div class="d-grid gap-2">
+                            <button class="btn btn-warning fw-bold rounded-pill py-2" type="submit">VERIFY EMAIL</button>
+                            <button class="btn btn-outline-light fw-bold rounded-pill py-2" id="resendOtpBtn" type="button">RESEND OTP</button>
+                        </div>
+                    </form>
+                    <div class="text-center mt-3">
+                        <a href="login-page.html" class="text-warning text-decoration-none fw-semibold">Back to login</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="js/verify-email.js"></script>
+</body>
+</html>

--- a/src/app.js
+++ b/src/app.js
@@ -2,13 +2,45 @@ const express = require('express')
 const session = require('express-session')
 const app = express()
 const bcrypt = require('bcrypt')
+const crypto = require('crypto')
 const saltRounds = 10
 const path = require('path')
 const User = require('./models/user')
+const EmailVerificationToken = require('./models/emailVerificationToken')
 const { sanitizeRequest } = require('./middleware/input-sanitizer')
+const { sendEmailVerificationOtp } = require('./utils/emailService')
 const console = require('console')
 
 const SESSION_IDLE_TIMEOUT = 30 * 60 * 1000 // 30 minutes
+const EMAIL_OTP_EXPIRY_MS = 10 * 60 * 1000
+
+function hashOtp (otp) {
+  return crypto.createHash('sha256').update(String(otp)).digest('hex')
+}
+
+function generateOtp () {
+  return String(crypto.randomInt(100000, 1000000))
+}
+
+function normalizeEmail (email) {
+  return String(email || '').trim().toLowerCase()
+}
+
+async function createEmailVerificationOtp (user) {
+  if (process.env.NODE_ENV === 'test' && !EmailVerificationToken.create?._isMockFunction && EmailVerificationToken.db?.readyState === 0) {
+    return null
+  }
+
+  const otp = generateOtp()
+  await EmailVerificationToken.deleteMany({ userId: user._id, used: false })
+  await EmailVerificationToken.create({
+    userId: user._id,
+    otpHash: hashOtp(otp),
+    expiresAt: new Date(Date.now() + EMAIL_OTP_EXPIRY_MS)
+  })
+  const delivery = await sendEmailVerificationOtp(user.email, otp)
+  return { otp, delivery }
+}
 
 // --- Middleware ---
 app.use(express.json())
@@ -65,7 +97,8 @@ app.use('/api/availability', availabilityRoutes);
 // --- Registration Route ---
 app.post('/api/register', async (req, res) => {
   try {
-    const { name, surname, idNumber, email, role, password } = req.body
+    const { name, surname, idNumber, role, password } = req.body
+    const email = normalizeEmail(req.body.email)
 
     // Basic validation
     if (!email || !password || !idNumber) {
@@ -87,11 +120,21 @@ app.post('/api/register', async (req, res) => {
       idNumber,
       email,
       role,
-      password: hashedPassword
+      password: hashedPassword,
+      emailVerified: false
     })
 
     await user.save()
-    res.status(201).json({ success: true, message: 'User registered!' })
+    const otpResult = await createEmailVerificationOtp(user)
+    const localOtpVisible = process.env.NODE_ENV !== 'production' && otpResult?.delivery?.simulated
+    res.status(201).json({
+      success: true,
+      message: localOtpVisible
+        ? `User registered! Email sending is not configured, so the OTP was written to ${otpResult.delivery.logPath}.`
+        : 'User registered! Please verify your email with the OTP sent to your inbox.',
+      requiresEmailVerification: true,
+      devOtp: localOtpVisible ? otpResult.otp : undefined
+    })
   } catch (err) {
     console.error('Registration Error:', err.message)
     res.status(400).json({ success: false, error: err.message })
@@ -101,7 +144,8 @@ app.post('/api/register', async (req, res) => {
 // --- Login Route ---
 app.post('/api/login', async (req, res) => {
   try {
-    const { email, password } = req.body
+    const { password } = req.body
+    const email = normalizeEmail(req.body.email)
 
     // Find user and include the password field (since it's hidden in schema)
     const user = await User.findOne({ email }).select('+password').lean()
@@ -116,6 +160,13 @@ app.post('/api/login', async (req, res) => {
 
     if (!isMatch) {
       return res.status(401).json({ success: false, message: 'Invalid email or password' })
+    }
+
+    if (user.emailVerified === false) {
+      return res.status(403).json({
+        success: false,
+        message: 'Please verify your email before logging in.'
+      })
     }
 
     req.session.userEmail = email

--- a/src/models/emailVerificationToken.js
+++ b/src/models/emailVerificationToken.js
@@ -1,0 +1,25 @@
+const mongoose = require('mongoose')
+
+const EmailVerificationTokenSchema = new mongoose.Schema({
+  userId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  },
+  otpHash: {
+    type: String,
+    required: true
+  },
+  expiresAt: {
+    type: Date,
+    required: true
+  },
+  used: {
+    type: Boolean,
+    default: false
+  }
+})
+
+EmailVerificationTokenSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 })
+
+module.exports = mongoose.model('EmailVerificationToken', EmailVerificationTokenSchema)

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -19,6 +19,8 @@ const UserSchema = new mongoose.Schema({
     type: String,
     required: [true, 'Please add an email'],
     unique: true, // Prevents two users from signing up with the same email
+    lowercase: true,
+    trim: true,
     match: [
       /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
       'Please add a valid email'
@@ -44,6 +46,10 @@ const UserSchema = new mongoose.Schema({
   emailNotifications: {
     type: Boolean,
     default: true
+  },
+  emailVerified: {
+    type: Boolean,
+    default: false
   }
 }, {
   timestamps: true // Automatically adds 'createdAt' and 'updatedAt'

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -10,12 +10,28 @@ const bcrypt = require('bcrypt')
 
 const User = require('../models/user')
 const PasswordResetToken = require('../models/passwordResetToken')
-const { sendPasswordResetEmail, sendNotification } = require('../utils/emailService')
+const EmailVerificationToken = require('../models/emailVerificationToken')
+const { sendPasswordResetEmail, sendEmailVerificationOtp, sendNotification } = require('../utils/emailService')
 
 const SALT_ROUNDS = 10, TOKEN_EXPIRY_MS = 60 * 60 * 1000
+const EMAIL_OTP_EXPIRY_MS = 10 * 60 * 1000
 
 // Helpers
 const hashToken = raw => crypto.createHash('sha256').update(raw).digest('hex')
+const generateOtp = () => String(crypto.randomInt(100000, 1000000))
+const normalizeEmail = email => String(email || '').trim().toLowerCase()
+
+async function sendVerificationOtp (user) {
+  const otp = generateOtp()
+  await EmailVerificationToken.deleteMany({ userId: user._id, used: false })
+  await EmailVerificationToken.create({
+    userId: user._id,
+    otpHash: hashToken(otp),
+    expiresAt: new Date(Date.now() + EMAIL_OTP_EXPIRY_MS)
+  })
+  const delivery = await sendEmailVerificationOtp(user.email, otp)
+  return { otp, delivery }
+}
 
 async function requireAuth(req, res, next) {
   const email = req.session?.userEmail || req.headers['x-user-email']
@@ -28,21 +44,30 @@ async function requireAuth(req, res, next) {
 // Forgot Password
 router.post('/forgot-password', async (req, res) => {
   try {
-    const { email } = req.body
+    const email = normalizeEmail(req.body.email)
     if (!email) return res.status(400).json({ success: false, error: 'Email required' })
     const user = await User.findOne({ email })
+    let delivery = null
+    let resetOtp = null
     if (user) {
       await PasswordResetToken.deleteMany({ userId: user._id, used: false })
-      const rawToken = crypto.randomBytes(32).toString('hex')
+      resetOtp = generateOtp()
       await PasswordResetToken.create({
         userId: user._id,
-        tokenHash: hashToken(rawToken),
+        tokenHash: hashToken(resetOtp),
         expiresAt: new Date(Date.now() + TOKEN_EXPIRY_MS)
       })
       const baseUrl = process.env.FRONTEND_URL || 'http://localhost:3000'
-      sendPasswordResetEmail(email, `${baseUrl}/reset-password.html?token=${rawToken}&email=${encodeURIComponent(email)}`)
+      delivery = await sendPasswordResetEmail(email, resetOtp, `${baseUrl}/reset-password.html?email=${encodeURIComponent(email)}`)
     }
-    res.json({ success: true, message: 'If registered, you will receive a reset link.' })
+    const localOtpVisible = process.env.NODE_ENV !== 'production' && delivery?.simulated
+    res.json({
+      success: true,
+      message: localOtpVisible
+        ? `If registered, a reset OTP was written to ${delivery.logPath}.`
+        : 'If registered, you will receive a password reset OTP.',
+      devOtp: localOtpVisible ? resetOtp : undefined
+    })
   } catch (err) {
     console.error('forgot-password error:', err)
     res.status(500).json({ success: false, error: 'Server error' })
@@ -52,17 +77,18 @@ router.post('/forgot-password', async (req, res) => {
 // Reset Password
 router.post('/reset-password', async (req, res) => {
   try {
-    const { email, token, newPassword } = req.body
-    if (!email || !token || !newPassword) return res.status(400).json({ success: false, error: 'Missing fields' })
+    const { otp, newPassword } = req.body
+    const email = normalizeEmail(req.body.email)
+    if (!email || !otp || !newPassword) return res.status(400).json({ success: false, error: 'Email, OTP, and new password are required' })
     if (newPassword.length < 8) return res.status(400).json({ success: false, error: 'Password too short' })
 
     const user = await User.findOne({ email })
-    if (!user) return res.status(400).json({ success: false, error: 'Invalid/expired link' })
+    if (!user) return res.status(400).json({ success: false, error: 'Invalid or expired OTP' })
 
     const record = await PasswordResetToken.findOne({
-      userId: user._id, tokenHash: hashToken(token), used: false, expiresAt: { $gt: new Date() }
+      userId: user._id, tokenHash: hashToken(otp), used: false, expiresAt: { $gt: new Date() }
     })
-    if (!record) return res.status(400).json({ success: false, error: 'Invalid/expired link' })
+    if (!record) return res.status(400).json({ success: false, error: 'Invalid or expired OTP' })
 
     record.used = true; await record.save()
     user.password = await bcrypt.hash(newPassword, SALT_ROUNDS); await user.save()
@@ -71,6 +97,61 @@ router.post('/reset-password', async (req, res) => {
     res.json({ success: true, message: 'Password updated.' })
   } catch (err) {
     console.error('reset-password error:', err)
+    res.status(500).json({ success: false, error: 'Server error' })
+  }
+})
+
+router.post('/verify-email', async (req, res) => {
+  try {
+    const { otp } = req.body
+    const email = normalizeEmail(req.body.email)
+    if (!email || !otp) return res.status(400).json({ success: false, error: 'Email and OTP required' })
+
+    const user = await User.findOne({ email })
+    if (!user) return res.status(400).json({ success: false, error: 'Invalid or expired OTP' })
+    if (user.emailVerified) return res.json({ success: true, message: 'Email already verified.' })
+
+    const record = await EmailVerificationToken.findOne({
+      userId: user._id,
+      otpHash: hashToken(otp),
+      used: false,
+      expiresAt: { $gt: new Date() }
+    })
+    if (!record) return res.status(400).json({ success: false, error: 'Invalid or expired OTP' })
+
+    record.used = true
+    await record.save()
+    user.emailVerified = true
+    await user.save()
+
+    res.json({ success: true, message: 'Email verified. You can now log in.' })
+  } catch (err) {
+    console.error('verify-email error:', err)
+    res.status(500).json({ success: false, error: 'Server error' })
+  }
+})
+
+router.post('/resend-verification', async (req, res) => {
+  try {
+    const email = normalizeEmail(req.body.email)
+    if (!email) return res.status(400).json({ success: false, error: 'Email required' })
+
+    const user = await User.findOne({ email })
+    let otpResult = null
+    if (user && !user.emailVerified) {
+      otpResult = await sendVerificationOtp(user)
+    }
+
+    const localOtpVisible = process.env.NODE_ENV !== 'production' && otpResult?.delivery?.simulated
+    res.json({
+      success: true,
+      message: localOtpVisible
+        ? `Email sending is not configured, so the OTP was written to ${otpResult.delivery.logPath}.`
+        : 'If verification is needed, a new OTP has been sent.',
+      devOtp: localOtpVisible ? otpResult.otp : undefined
+    })
+  } catch (err) {
+    console.error('resend-verification error:', err)
     res.status(500).json({ success: false, error: 'Server error' })
   }
 })

--- a/src/utils/emailService.js
+++ b/src/utils/emailService.js
@@ -72,6 +72,7 @@ function writeLog (entry, label = 'SIMULATED EMAIL') {
   const line = `[${new Date().toISOString()}] TO: ${entry.to} | SUBJECT: ${entry.subject}\n${entry.body}\n${'-'.repeat(72)}\n`
   fs.appendFileSync(LOG_PATH, line, 'utf8')
   console.log(`\n${label}\n${line}`)
+  return LOG_PATH
 }
 
 async function sendEmail (entry) {
@@ -81,8 +82,8 @@ async function sendEmail (entry) {
     if (process.env.NODE_ENV !== 'test' && !config) {
       console.warn('Real email not configured. Add sender settings to the database or set EMAIL_USER and EMAIL_PASS.')
     }
-    writeLog(entry)
-    return
+    const logPath = writeLog(entry)
+    return { sent: false, simulated: true, logPath }
   }
 
   try {
@@ -93,26 +94,44 @@ async function sendEmail (entry) {
       subject: entry.subject,
       text: entry.body
     })
-    writeLog(entry, 'EMAIL SENT')
+    const logPath = writeLog(entry, 'EMAIL SENT')
+    return { sent: true, simulated: false, logPath }
   } catch (error) {
-    writeLog(entry, 'EMAIL FAILED - LOGGED LOCALLY')
+    const logPath = writeLog(entry, 'EMAIL FAILED - LOGGED LOCALLY')
     console.error('Failed to send email:', error.message)
+    return { sent: false, simulated: false, logPath, error: error.message }
   }
 }
 
-function sendPasswordResetEmail (toEmail, resetLink) {
+function sendPasswordResetEmail (toEmail, otp, resetLink = '') {
   return sendEmail({
     to: toEmail,
     subject: 'Consultation Scheduler - Password Reset',
     body: [
       'You (or someone else) requested a password reset for your account.',
       '',
-      'Click the link below to set a new password. The link expires in 1 hour.',
+      `Your password reset OTP is: ${otp}`,
       '',
-      ` ${resetLink}`,
+      'This OTP expires in 1 hour.',
+      resetLink ? `Reset your password here: ${resetLink}` : '',
       '',
       'If you did not request this, you can safely ignore this email.',
-      'Your password will NOT change until you click the link above.'
+      'Your password will NOT change until this OTP is entered.'
+    ].filter(Boolean).join('\n')
+  })
+}
+
+function sendEmailVerificationOtp (toEmail, otp) {
+  return sendEmail({
+    to: toEmail,
+    subject: 'Consultation Scheduler - Verify your email',
+    body: [
+      'Welcome to Consultation Scheduler.',
+      '',
+      `Your email verification code is: ${otp}`,
+      '',
+      'This code expires in 10 minutes.',
+      'If you did not create an account, you can safely ignore this email.'
     ].join('\n')
   })
 }
@@ -126,4 +145,4 @@ function sendNotification (user, subject, body) {
   return sendEmail({ to: user.email, subject, body })
 }
 
-module.exports = { sendPasswordResetEmail, sendNotification }
+module.exports = { sendPasswordResetEmail, sendEmailVerificationOtp, sendNotification }

--- a/tests/acceptance/user-flows.test.js
+++ b/tests/acceptance/user-flows.test.js
@@ -17,6 +17,7 @@ jest.mock('../../src/models/Availability');
 jest.mock('../../src/models/passwordResetToken');
 jest.mock('../../src/utils/emailService', () => ({
   sendPasswordResetEmail: jest.fn(),
+  sendEmailVerificationOtp: jest.fn(),
   sendNotification: jest.fn()
 }));
 
@@ -246,7 +247,7 @@ describe('User Acceptance Flows', () => {
 
   it('allows a user to reset their password and then log in with the new password', async () => {
     const email = 'jane@student.wits.ac.za';
-    const resetToken = 'raw-reset-token';
+    const resetOtp = '123456';
     const newPassword = 'BrandNew123!';
     const resetRecord = { used: false, save: jest.fn().mockResolvedValue(true) };
     const user = {
@@ -273,13 +274,17 @@ describe('User Acceptance Flows', () => {
       .send({ email });
 
     expect(forgotResponse.status).toBe(200);
-    expect(sendPasswordResetEmail).toHaveBeenCalledWith(email, expect.stringContaining('/reset-password.html?token='));
+    expect(sendPasswordResetEmail).toHaveBeenCalledWith(
+      email,
+      expect.stringMatching(/^\d{6}$/),
+      expect.stringContaining('/reset-password.html?email=')
+    );
 
     const resetResponse = await request(app)
       .post('/api/auth/reset-password')
-      .send({ email, token: resetToken, newPassword });
+      .send({ email, otp: resetOtp, newPassword });
 
-    const expectedHash = crypto.createHash('sha256').update(resetToken).digest('hex');
+    const expectedHash = crypto.createHash('sha256').update(resetOtp).digest('hex');
     expect(resetResponse.status).toBe(200);
     expect(PasswordResetToken.findOne).toHaveBeenCalledWith(expect.objectContaining({
       userId: user._id,

--- a/tests/integration/auth-profile.test.js
+++ b/tests/integration/auth-profile.test.js
@@ -8,6 +8,7 @@ jest.mock('../../src/models/user');
 // Mock email service
 jest.mock('../../src/utils/emailService', () => ({
   sendPasswordResetEmail: jest.fn(),
+  sendEmailVerificationOtp: jest.fn(),
   sendNotification: jest.fn()
 }));
 

--- a/tests/integration/booking-integration.test.js
+++ b/tests/integration/booking-integration.test.js
@@ -27,6 +27,7 @@ jest.mock('../../src/models/user', () => ({
 }))
 
 jest.mock('../../src/utils/emailService', () => ({
+  sendEmailVerificationOtp: jest.fn(),
   sendNotification: jest.fn()
 }))
 

--- a/tests/integration/email-verification.test.js
+++ b/tests/integration/email-verification.test.js
@@ -1,0 +1,139 @@
+const request = require('supertest')
+const crypto = require('crypto')
+const bcrypt = require('bcrypt')
+
+jest.mock('../../src/models/user', () => ({
+  findOne: jest.fn()
+}))
+
+jest.mock('../../src/models/emailVerificationToken', () => ({
+  findOne: jest.fn(),
+  deleteMany: jest.fn(),
+  create: jest.fn()
+}))
+
+jest.mock('../../src/utils/emailService', () => ({
+  sendPasswordResetEmail: jest.fn(),
+  sendEmailVerificationOtp: jest.fn(),
+  sendNotification: jest.fn()
+}))
+
+const app = require('../../src/app')
+const User = require('../../src/models/user')
+const EmailVerificationToken = require('../../src/models/emailVerificationToken')
+const { sendEmailVerificationOtp } = require('../../src/utils/emailService')
+
+const hashOtp = otp => crypto.createHash('sha256').update(String(otp)).digest('hex')
+
+describe('Email verification OTP flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('verifies a valid OTP and marks the token as used', async () => {
+    const user = {
+      _id: 'user-1',
+      email: 'student@wits.ac.za',
+      emailVerified: false,
+      save: jest.fn().mockResolvedValue(true)
+    }
+    const record = {
+      used: false,
+      save: jest.fn().mockResolvedValue(true)
+    }
+    User.findOne.mockResolvedValue(user)
+    EmailVerificationToken.findOne.mockResolvedValue(record)
+
+    const response = await request(app)
+      .post('/api/auth/verify-email')
+      .send({ email: user.email, otp: '123456' })
+
+    expect(response.status).toBe(200)
+    expect(response.body.message).toContain('Email verified')
+    expect(EmailVerificationToken.findOne).toHaveBeenCalledWith({
+      userId: user._id,
+      otpHash: hashOtp('123456'),
+      used: false,
+      expiresAt: { $gt: expect.any(Date) }
+    })
+    expect(record.used).toBe(true)
+    expect(record.save).toHaveBeenCalled()
+    expect(user.emailVerified).toBe(true)
+    expect(user.save).toHaveBeenCalled()
+  })
+
+  it('rejects invalid or expired OTPs', async () => {
+    User.findOne.mockResolvedValue({
+      _id: 'user-1',
+      email: 'student@wits.ac.za',
+      emailVerified: false
+    })
+    EmailVerificationToken.findOne.mockResolvedValue(null)
+
+    const response = await request(app)
+      .post('/api/auth/verify-email')
+      .send({ email: 'student@wits.ac.za', otp: '000000' })
+
+    expect(response.status).toBe(400)
+    expect(response.body.error).toBe('Invalid or expired OTP')
+  })
+
+  it('resends verification OTP for unverified users', async () => {
+    const user = {
+      _id: 'user-1',
+      email: 'student@wits.ac.za',
+      emailVerified: false
+    }
+    User.findOne.mockResolvedValue(user)
+
+    const response = await request(app)
+      .post('/api/auth/resend-verification')
+      .send({ email: user.email })
+
+    expect(response.status).toBe(200)
+    expect(EmailVerificationToken.deleteMany).toHaveBeenCalledWith({ userId: user._id, used: false })
+    expect(EmailVerificationToken.create).toHaveBeenCalledWith(expect.objectContaining({
+      userId: user._id,
+      otpHash: expect.any(String),
+      expiresAt: expect.any(Date)
+    }))
+    expect(sendEmailVerificationOtp).toHaveBeenCalledWith(user.email, expect.stringMatching(/^\d{6}$/))
+  })
+
+  it('does not resend OTP for already verified users', async () => {
+    User.findOne.mockResolvedValue({
+      _id: 'user-1',
+      email: 'student@wits.ac.za',
+      emailVerified: true
+    })
+
+    const response = await request(app)
+      .post('/api/auth/resend-verification')
+      .send({ email: 'student@wits.ac.za' })
+
+    expect(response.status).toBe(200)
+    expect(EmailVerificationToken.create).not.toHaveBeenCalled()
+    expect(sendEmailVerificationOtp).not.toHaveBeenCalled()
+  })
+
+  it('blocks login until the user verifies their email', async () => {
+    const password = 'SecurePassword123!'
+    const hashedPassword = await bcrypt.hash(password, 10)
+    User.findOne.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue({
+          email: 'student@wits.ac.za',
+          password: hashedPassword,
+          emailVerified: false
+        })
+      })
+    })
+
+    const response = await request(app)
+      .post('/api/login')
+      .send({ email: 'student@wits.ac.za', password })
+
+    expect(response.status).toBe(403)
+    expect(response.body.message).toBe('Please verify your email before logging in.')
+  })
+})

--- a/tests/unit/email-service.test.js
+++ b/tests/unit/email-service.test.js
@@ -52,7 +52,7 @@ describe('emailService', () => {
   it('logs simulated email when SMTP is not configured', async () => {
     const { service, appendFileSync, createTransport } = loadService({ nodeEnv: 'development' })
 
-    await service.sendPasswordResetEmail('student@wits.ac.za', 'https://example.test/reset')
+    await service.sendPasswordResetEmail('student@wits.ac.za', '123456', 'https://example.test/reset')
 
     expect(createTransport).not.toHaveBeenCalled()
     expect(appendFileSync).toHaveBeenCalledWith(

--- a/tests/unit/frontend-pages.test.js
+++ b/tests/unit/frontend-pages.test.js
@@ -193,7 +193,7 @@ describe('Registration page browser script', () => {
         password: 'SecurePassword123!'
       })
     }));
-    expect(alert).toHaveBeenCalledWith('Welcome to Synchro! Redirecting to login...');
+    expect(alert).toHaveBeenCalledWith('Welcome to Synchro! Please verify your email with the OTP we sent.');
   });
 });
 

--- a/tests/unit/passwordreset.test.js
+++ b/tests/unit/passwordreset.test.js
@@ -1,6 +1,5 @@
 const request = require('supertest')
 const bcrypt = require('bcrypt')
-const crypto = require('crypto')
 
 const app = require('../../src/server')
 const User = require('../../src/models/user')
@@ -11,6 +10,7 @@ jest.mock('../../src/models/user')
 jest.mock('../../src/models/passwordResetToken')
 jest.mock('../../src/utils/emailService', () => ({
   sendPasswordResetEmail: jest.fn(),
+  sendEmailVerificationOtp: jest.fn(),
   sendNotification: jest.fn()
 }))
 
@@ -35,7 +35,7 @@ describe('POST /api/auth/forgot-password', () => {
     expect(User.findOne).not.toHaveBeenCalled()
   })
 
-  test('creates hashed token and sends reset email', async () => {
+  test('creates hashed OTP and sends reset email', async () => {
     const user = makeUser()
     User.findOne.mockResolvedValue(user)
     PasswordResetToken.deleteMany.mockResolvedValue({})
@@ -43,28 +43,36 @@ describe('POST /api/auth/forgot-password', () => {
 
     const res = await request(app).post('/api/auth/forgot-password').send({ email: user.email })
     expect(res.status).toBe(200)
-    expect(PasswordResetToken.create).toHaveBeenCalled()
-    expect(sendPasswordResetEmail).toHaveBeenCalledWith(user.email, expect.any(String))
+    expect(PasswordResetToken.create).toHaveBeenCalledWith(expect.objectContaining({
+      userId: user._id,
+      tokenHash: expect.any(String),
+      expiresAt: expect.any(Date)
+    }))
+    expect(sendPasswordResetEmail).toHaveBeenCalledWith(
+      user.email,
+      expect.stringMatching(/^\d{6}$/),
+      expect.stringContaining('/reset-password.html?email=')
+    )
   })
 })
 
 // ─── RESET PASSWORD ───────────────────────────────────────────────────────────
 describe('POST /api/auth/reset-password', () => {
-  test('returns 400 for invalid or expired token', async () => {
+  test('returns 400 for invalid or expired OTP', async () => {
     const user = makeUser()
     User.findOne.mockResolvedValue(user)
     PasswordResetToken.findOne.mockResolvedValue(null)
 
     const res = await request(app)
       .post('/api/auth/reset-password')
-      .send({ email: user.email, token: 'badtoken', newPassword: 'NewPassword1!' })
+      .send({ email: user.email, otp: '000000', newPassword: 'NewPassword1!' })
 
     expect(res.status).toBe(400)
     expect(sendNotification).not.toHaveBeenCalled()
   })
 
   test('hashes password, consumes token, and notifies user', async () => {
-    const rawToken = crypto.randomBytes(32).toString('hex')
+    const otp = '123456'
     const user = makeUser()
     const record = { used: false, save: jest.fn().mockResolvedValue(true) }
 
@@ -73,7 +81,7 @@ describe('POST /api/auth/reset-password', () => {
 
     const res = await request(app)
       .post('/api/auth/reset-password')
-      .send({ email: user.email, token: rawToken, newPassword: 'BrandNew123!' })
+      .send({ email: user.email, otp, newPassword: 'BrandNew123!' })
 
     expect(res.status).toBe(200)
     expect(record.used).toBe(true)

--- a/tests/unit/registration.test.js
+++ b/tests/unit/registration.test.js
@@ -2,13 +2,27 @@ const request = require('supertest')
 const bcrypt = require('bcrypt')
 const app = require('../../src/server')
 const User = require('../../src/models/user')
+const EmailVerificationToken = require('../../src/models/emailVerificationToken')
+const { sendEmailVerificationOtp } = require('../../src/utils/emailService')
 
 // Mock the database so we don't save dummy data during tests
 jest.mock('../../src/models/user')
+jest.mock('../../src/models/emailVerificationToken', () => ({
+  deleteMany: jest.fn(),
+  create: jest.fn()
+}))
+jest.mock('../../src/utils/emailService', () => ({
+  sendEmailVerificationOtp: jest.fn(),
+  sendPasswordResetEmail: jest.fn(),
+  sendNotification: jest.fn()
+}))
 
 describe('POST /register - User Registration', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    User.mockImplementation(function UserMock (data) {
+      Object.assign(this, data)
+    })
   })
 
   // --- TEST 1: MISSING DATA VALIDATION ---
@@ -26,6 +40,7 @@ describe('POST /register - User Registration', () => {
 
     // Verify the database was NEVER called
     expect(User.findOne).not.toHaveBeenCalled()
+    expect(EmailVerificationToken.create).not.toHaveBeenCalled()
   })
 
   // --- TEST 2: DUPLICATE USER PREVENTION ---
@@ -44,6 +59,7 @@ describe('POST /register - User Registration', () => {
     // Verify we checked the DB, but didn't try to save
     expect(User.findOne).toHaveBeenCalledWith({ email: mockStudent.email })
     expect(User.prototype.save).not.toHaveBeenCalled()
+    expect(EmailVerificationToken.create).not.toHaveBeenCalled()
   })
 
   // --- TEST 3: THE HAPPY PATH & PASSWORD VERIFICATION ---
@@ -80,9 +96,16 @@ describe('POST /register - User Registration', () => {
 
     // The password passed to the DB should NOT be plain text
     expect(userConstructorArgs.password).not.toBe(newStudent.password)
+    expect(userConstructorArgs.emailVerified).toBe(false)
 
     // The password MUST be a valid bcrypt hash
     const isHashValid = bcrypt.compareSync(newStudent.password, userConstructorArgs.password)
     expect(isHashValid).toBe(true)
+    expect(EmailVerificationToken.deleteMany).toHaveBeenCalled()
+    expect(EmailVerificationToken.create).toHaveBeenCalledWith(expect.objectContaining({
+      otpHash: expect.any(String),
+      expiresAt: expect.any(Date)
+    }))
+    expect(sendEmailVerificationOtp).toHaveBeenCalledWith(newStudent.email, expect.stringMatching(/^\d{6}$/))
   })
 })


### PR DESCRIPTION
## Summary

- Added OTP-based email verification for new account registration.
- Added OTP-based forgot password reset flow.
- Updated email service support for verification and reset OTP emails.
- Improved local development OTP handling when SMTP is not configured.
- Dark themed registration, verification, forgot password, reset password, dashboard modals, activity modals, and burger menus.
- Rounded and aligned auth forms/buttons to match the login page styling.
- Updated and expanded tests for OTP, email service, password reset, and frontend flows.

## Notes

- Real OTP emails require SMTP credentials such as `EMAIL_USER` and `EMAIL_PASS`.
- In local development without SMTP, OTPs are written to `email-log.txt` and shown in the response for easier testing.