### PR TITLE
fix: add SMTP timeout handling for email delivery

### DIFF
--- a/src/utils/emailService.js
+++ b/src/utils/emailService.js
@@ -5,6 +5,12 @@ const nodemailer = require('nodemailer')
 const EmailSettings = require('../models/emailSettings')
 
 const LOG_PATH = path.resolve(__dirname, '../../email-log.txt')
+const DEFAULT_EMAIL_TIMEOUT_MS = 10000
+
+function getEmailTimeoutMs () {
+  const value = Number(process.env.EMAIL_TIMEOUT_MS || process.env.SMTP_TIMEOUT_MS)
+  return Number.isFinite(value) && value > 0 ? value : DEFAULT_EMAIL_TIMEOUT_MS
+}
 
 function getEnvEmailConfig () {
   const user = process.env.SMTP_USER || process.env.EMAIL_USER
@@ -19,7 +25,8 @@ function getEnvEmailConfig () {
     secure: String(process.env.SMTP_SECURE).toLowerCase() === 'true',
     user,
     pass,
-    from: process.env.SMTP_FROM || process.env.EMAIL_FROM || user
+    from: process.env.SMTP_FROM || process.env.EMAIL_FROM || user,
+    timeoutMs: getEmailTimeoutMs()
   }
 }
 
@@ -38,7 +45,8 @@ async function getDatabaseEmailConfig () {
     secure: Boolean(settings.secure),
     user: settings.user,
     pass: settings.pass,
-    from: settings.from || settings.user
+    from: settings.from || settings.user,
+    timeoutMs: getEmailTimeoutMs()
   }
 }
 
@@ -47,13 +55,20 @@ async function getEmailConfig () {
 }
 
 function createTransporter (config) {
+  const timeoutOptions = {
+    connectionTimeout: config.timeoutMs,
+    greetingTimeout: config.timeoutMs,
+    socketTimeout: config.timeoutMs
+  }
+
   if (config.service && !config.host) {
     return nodemailer.createTransport({
       service: config.service,
       auth: {
         user: config.user,
         pass: config.pass
-      }
+      },
+      ...timeoutOptions
     })
   }
 
@@ -64,8 +79,18 @@ function createTransporter (config) {
     auth: {
       user: config.user,
       pass: config.pass
-    }
+    },
+    ...timeoutOptions
   })
+}
+
+function withTimeout (promise, timeoutMs, message) {
+  return Promise.race([
+    promise,
+    new Promise((resolve, reject) => {
+      setTimeout(() => reject(new Error(message)), timeoutMs)
+    })
+  ])
 }
 
 function writeLog (entry, label = 'SIMULATED EMAIL') {
@@ -88,12 +113,16 @@ async function sendEmail (entry) {
 
   try {
     const transporter = createTransporter(config)
-    await transporter.sendMail({
-      from: config.from,
-      to: entry.to,
-      subject: entry.subject,
-      text: entry.body
-    })
+    await withTimeout(
+      transporter.sendMail({
+        from: config.from,
+        to: entry.to,
+        subject: entry.subject,
+        text: entry.body
+      }),
+      config.timeoutMs,
+      `Email send timed out after ${config.timeoutMs}ms`
+    )
     const logPath = writeLog(entry, 'EMAIL SENT')
     return { sent: true, simulated: false, logPath }
   } catch (error) {

--- a/tests/unit/email-service.test.js
+++ b/tests/unit/email-service.test.js
@@ -88,7 +88,10 @@ describe('emailService', () => {
       auth: {
         user: 'sender@example.test',
         pass: 'secret'
-      }
+      },
+      connectionTimeout: 10000,
+      greetingTimeout: 10000,
+      socketTimeout: 10000
     })
     expect(createTransport.mock.results[0].value.sendMail).toHaveBeenCalledWith({
       from: 'no-reply@example.test',
@@ -127,6 +130,9 @@ describe('emailService', () => {
     expect(findOne).toHaveBeenCalledWith({ name: 'default', enabled: true })
     expect(createTransport).toHaveBeenCalledWith(expect.objectContaining({
       host: 'smtp.db.test',
+      connectionTimeout: 10000,
+      greetingTimeout: 10000,
+      socketTimeout: 10000,
       auth: {
         user: 'db@example.test',
         pass: 'db-secret'
@@ -157,8 +163,44 @@ describe('emailService', () => {
       auth: {
         user: 'sender@gmail.com',
         pass: 'secret'
+      },
+      connectionTimeout: 10000,
+      greetingTimeout: 10000,
+      socketTimeout: 10000
+    })
+    expect(appendFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('email-log.txt'),
+      expect.stringContaining('TO: lecturer@wits.ac.za | SUBJECT: Subject'),
+      'utf8'
+    )
+  })
+
+  it('returns when SMTP hangs instead of waiting forever', async () => {
+    const { service, createTransport, appendFileSync } = loadService({
+      nodeEnv: 'development',
+      env: {
+        EMAIL_USER: 'sender@gmail.com',
+        EMAIL_PASS: 'secret',
+        EMAIL_TIMEOUT_MS: '5'
       }
     })
+    createTransport.mockReturnValueOnce({
+      sendMail: jest.fn(() => new Promise(() => {}))
+    })
+
+    const result = await service.sendNotification(
+      { email: 'lecturer@wits.ac.za', emailNotifications: true },
+      'Subject',
+      'Body'
+    )
+
+    expect(result.sent).toBe(false)
+    expect(result.error).toContain('timed out')
+    expect(createTransport).toHaveBeenCalledWith(expect.objectContaining({
+      connectionTimeout: 5,
+      greetingTimeout: 5,
+      socketTimeout: 5
+    }))
     expect(appendFileSync).toHaveBeenCalledWith(
       expect.stringContaining('email-log.txt'),
       expect.stringContaining('TO: lecturer@wits.ac.za | SUBJECT: Subject'),


### PR DESCRIPTION
## Summary

- Added SMTP timeout handling so email delivery does not hang indefinitely on Render.
- Added connection, greeting, socket, and app-level send timeouts for Nodemailer.
- Logged failed or timed-out email attempts locally instead of blocking the request.
- Added test coverage for SMTP timeout behavior.

## Notes

- Render needs email environment variables configured, for example:
  - `EMAIL_USER`
  - `EMAIL_PASS`
  - `EMAIL_TIMEOUT_MS`
- For Gmail, `EMAIL_PASS` must be an app password.