### PR TITLE
fix: improve production email failure handling

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -42,6 +42,10 @@ async function createEmailVerificationOtp (user) {
   return { otp, delivery }
 }
 
+function shouldBlockOtpWhenEmailFails (delivery) {
+  return process.env.NODE_ENV === 'production' && delivery && !delivery.sent
+}
+
 // --- Middleware ---
 app.use(express.json())
 app.use(session({
@@ -126,6 +130,12 @@ app.post('/api/register', async (req, res) => {
 
     await user.save()
     const otpResult = await createEmailVerificationOtp(user)
+    if (shouldBlockOtpWhenEmailFails(otpResult?.delivery)) {
+      return res.status(502).json({
+        success: false,
+        error: 'Account created, but the verification email could not be sent. Please contact support or try resend verification later.'
+      })
+    }
     const localOtpVisible = process.env.NODE_ENV !== 'production' && otpResult?.delivery?.simulated
     res.status(201).json({
       success: true,

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -21,6 +21,10 @@ const hashToken = raw => crypto.createHash('sha256').update(raw).digest('hex')
 const generateOtp = () => String(crypto.randomInt(100000, 1000000))
 const normalizeEmail = email => String(email || '').trim().toLowerCase()
 
+function shouldBlockOtpWhenEmailFails (delivery) {
+  return process.env.NODE_ENV === 'production' && delivery && !delivery.sent
+}
+
 async function sendVerificationOtp (user) {
   const otp = generateOtp()
   await EmailVerificationToken.deleteMany({ userId: user._id, used: false })
@@ -59,6 +63,12 @@ router.post('/forgot-password', async (req, res) => {
       })
       const baseUrl = process.env.FRONTEND_URL || 'http://localhost:3000'
       delivery = await sendPasswordResetEmail(email, resetOtp, `${baseUrl}/reset-password.html?email=${encodeURIComponent(email)}`)
+    }
+    if (shouldBlockOtpWhenEmailFails(delivery)) {
+      return res.status(502).json({
+        success: false,
+        error: 'Password reset email could not be sent. Please try again shortly.'
+      })
     }
     const localOtpVisible = process.env.NODE_ENV !== 'production' && delivery?.simulated
     res.json({
@@ -140,6 +150,12 @@ router.post('/resend-verification', async (req, res) => {
     let otpResult = null
     if (user && !user.emailVerified) {
       otpResult = await sendVerificationOtp(user)
+    }
+    if (shouldBlockOtpWhenEmailFails(otpResult?.delivery)) {
+      return res.status(502).json({
+        success: false,
+        error: 'Verification email could not be sent. Please try again shortly.'
+      })
     }
 
     const localOtpVisible = process.env.NODE_ENV !== 'production' && otpResult?.delivery?.simulated

--- a/src/utils/emailService.js
+++ b/src/utils/emailService.js
@@ -12,9 +12,13 @@ function getEmailTimeoutMs () {
   return Number.isFinite(value) && value > 0 ? value : DEFAULT_EMAIL_TIMEOUT_MS
 }
 
+function normalizeEmailPassword (pass) {
+  return String(pass || '').replace(/\s+/g, '')
+}
+
 function getEnvEmailConfig () {
   const user = process.env.SMTP_USER || process.env.EMAIL_USER
-  const pass = process.env.SMTP_PASS || process.env.EMAIL_PASS
+  const pass = normalizeEmailPassword(process.env.SMTP_PASS || process.env.EMAIL_PASS)
 
   if (!user || !pass) return null
 
@@ -37,6 +41,7 @@ async function getDatabaseEmailConfig () {
 
   const settings = await EmailSettings.findOne({ name: 'default', enabled: true }).lean()
   if (!settings || !settings.user || !settings.pass) return null
+  const pass = normalizeEmailPassword(settings.pass)
 
   return {
     service: settings.service || (settings.user.includes('@gmail.com') ? 'gmail' : ''),
@@ -44,7 +49,7 @@ async function getDatabaseEmailConfig () {
     port: Number(settings.port) || 587,
     secure: Boolean(settings.secure),
     user: settings.user,
-    pass: settings.pass,
+    pass,
     from: settings.from || settings.user,
     timeoutMs: getEmailTimeoutMs()
   }

--- a/tests/unit/email-service.test.js
+++ b/tests/unit/email-service.test.js
@@ -175,6 +175,30 @@ describe('emailService', () => {
     )
   })
 
+  it('removes spaces from Gmail app passwords pasted from the Google UI', async () => {
+    const { service, createTransport } = loadService({
+      nodeEnv: 'development',
+      env: {
+        EMAIL_USER: 'sender@gmail.com',
+        EMAIL_PASS: 'abcd efgh ijkl mnop'
+      }
+    })
+
+    await service.sendNotification(
+      { email: 'lecturer@wits.ac.za', emailNotifications: true },
+      'Subject',
+      'Body'
+    )
+
+    expect(createTransport).toHaveBeenCalledWith(expect.objectContaining({
+      service: 'gmail',
+      auth: {
+        user: 'sender@gmail.com',
+        pass: 'abcdefghijklmnop'
+      }
+    }))
+  })
+
   it('returns when SMTP hangs instead of waiting forever', async () => {
     const { service, createTransport, appendFileSync } = loadService({
       nodeEnv: 'development',


### PR DESCRIPTION
## Summary

- Improved production email failure handling for OTP flows.
- Added support for Gmail app passwords pasted with spaces.
- Return clear errors when verification or password reset emails fail to send in production.
- Kept local development behavior for simulated email logging.
- Added test coverage for Gmail app password normalization.

## Notes

Render should have these env vars configured:

- `NODE_ENV=production`
- `EMAIL_USER`
- `EMAIL_PASS`
- `EMAIL_SERVICE=gmail`
- `EMAIL_TIMEOUT_MS=10000`