### PR TITLE
bug: email send fix

### DIFF
--- a/scripts/save-email-settings.js
+++ b/scripts/save-email-settings.js
@@ -8,10 +8,17 @@ function getArg (name) {
   return index === -1 ? '' : process.argv[index + 1] || ''
 }
 
+function normalizeEmailPassword (pass) {
+  return String(pass || '')
+    .trim()
+    .replace(/^['"]|['"]$/g, '')
+    .replace(/\s+/g, '')
+}
+
 async function main () {
   const mongoUri = getArg('mongo') || process.env.MONGODB_URI
   const user = getArg('user')
-  const pass = getArg('pass')
+  const pass = normalizeEmailPassword(getArg('pass'))
   const from = getArg('from') || user
   const service = getArg('service') || (user.includes('@gmail.com') ? 'gmail' : '')
   const host = getArg('host')

--- a/src/utils/emailService.js
+++ b/src/utils/emailService.js
@@ -13,23 +13,30 @@ function getEmailTimeoutMs () {
 }
 
 function normalizeEmailPassword (pass) {
-  return String(pass || '').replace(/\s+/g, '')
+  return String(pass || '')
+    .trim()
+    .replace(/^['"]|['"]$/g, '')
+    .replace(/\s+/g, '')
+}
+
+function normalizeEnvString (value) {
+  return String(value || '').trim().replace(/^['"]|['"]$/g, '')
 }
 
 function getEnvEmailConfig () {
-  const user = process.env.SMTP_USER || process.env.EMAIL_USER
+  const user = normalizeEnvString(process.env.SMTP_USER || process.env.EMAIL_USER)
   const pass = normalizeEmailPassword(process.env.SMTP_PASS || process.env.EMAIL_PASS)
 
   if (!user || !pass) return null
 
   return {
-    service: process.env.EMAIL_SERVICE || (user.includes('@gmail.com') ? 'gmail' : ''),
-    host: process.env.SMTP_HOST || '',
+    service: normalizeEnvString(process.env.EMAIL_SERVICE) || (user.includes('@gmail.com') ? 'gmail' : ''),
+    host: normalizeEnvString(process.env.SMTP_HOST),
     port: Number(process.env.SMTP_PORT) || 587,
     secure: String(process.env.SMTP_SECURE).toLowerCase() === 'true',
     user,
     pass,
-    from: process.env.SMTP_FROM || process.env.EMAIL_FROM || user,
+    from: normalizeEnvString(process.env.SMTP_FROM || process.env.EMAIL_FROM || user),
     timeoutMs: getEmailTimeoutMs()
   }
 }

--- a/tests/unit/email-service.test.js
+++ b/tests/unit/email-service.test.js
@@ -179,8 +179,9 @@ describe('emailService', () => {
     const { service, createTransport } = loadService({
       nodeEnv: 'development',
       env: {
-        EMAIL_USER: 'sender@gmail.com',
-        EMAIL_PASS: 'abcd efgh ijkl mnop'
+        EMAIL_USER: ' "sender@gmail.com" ',
+        EMAIL_PASS: ' "abcd efgh ijkl mnop" ',
+        EMAIL_SERVICE: ' "gmail" '
       }
     })
 


### PR DESCRIPTION
## Title
fix: normalize Gmail App Password in save-email-settings script

## Description

### Problem
Emails were not being sent when the application was deployed on Render. Investigation revealed two issues:

1. **Wrong database target**: The `save-email-settings.js` script was previously run against the `/test` database (`...mongodb.net/test?...`), but the Render application connects to the **default database** (no `/test` path). This meant the `EmailSettings` document was not found at runtime by `getDatabaseEmailConfig()` in `src/utils/emailService.js`, causing all emails to be silently "simulated" (logged to Render's ephemeral filesystem) instead of actually sent.

2. **Password stored with spaces**: The script stored the Gmail App Password as-is (including the decorative spaces from Google's UI: `kkmv jcxt ljjq gldw`). While the runtime code in `normalizeEmailPassword()` strips these spaces when reading, it's better practice to normalize before saving for consistency.

