### PR TITLE
fix: email problem

### DIFF
--- a/email-log.txt
+++ b/email-log.txt
@@ -519,3 +519,8 @@ Topic: modals
 
 You can view this booking from your lecturer dashboard.
 ------------------------------------------------------------------------
+[2026-05-17T18:59:32.076Z] TO: mjiyako.ngcweti@gmail.com | SUBJECT: Consultation Scheduler test email
+This is a real email delivery test from Consultation Scheduler.
+
+If this reached your inbox, booking notifications can be delivered too.
+------------------------------------------------------------------------

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -25,6 +25,17 @@ function shouldBlockOtpWhenEmailFails (delivery) {
   return process.env.NODE_ENV === 'production' && delivery && !delivery.sent
 }
 
+function getPublicBaseUrl (req) {
+  const configuredUrl = process.env.FRONTEND_URL || process.env.PUBLIC_URL || process.env.APP_BASE_URL || process.env.RENDER_EXTERNAL_URL
+  if (configuredUrl) return configuredUrl.replace(/\/+$/, '')
+
+  const host = req.get('x-forwarded-host') || req.get('host')
+  if (!host) return 'http://localhost:3000'
+
+  const protocol = req.get('x-forwarded-proto') || req.protocol || 'http'
+  return `${protocol}://${host}`.replace(/\/+$/, '')
+}
+
 async function sendVerificationOtp (user) {
   const otp = generateOtp()
   await EmailVerificationToken.deleteMany({ userId: user._id, used: false })
@@ -61,7 +72,7 @@ router.post('/forgot-password', async (req, res) => {
         tokenHash: hashToken(resetOtp),
         expiresAt: new Date(Date.now() + TOKEN_EXPIRY_MS)
       })
-      const baseUrl = process.env.FRONTEND_URL || 'http://localhost:3000'
+      const baseUrl = getPublicBaseUrl(req)
       delivery = await sendPasswordResetEmail(email, resetOtp, `${baseUrl}/reset-password.html?email=${encodeURIComponent(email)}`)
     }
     if (shouldBlockOtpWhenEmailFails(delivery)) {

--- a/src/utils/emailService.js
+++ b/src/utils/emailService.js
@@ -5,7 +5,7 @@ const nodemailer = require('nodemailer')
 const EmailSettings = require('../models/emailSettings')
 
 const LOG_PATH = path.resolve(__dirname, '../../email-log.txt')
-const DEFAULT_EMAIL_TIMEOUT_MS = 10000
+const DEFAULT_EMAIL_TIMEOUT_MS = 30000
 
 function getEmailTimeoutMs () {
   const value = Number(process.env.EMAIL_TIMEOUT_MS || process.env.SMTP_TIMEOUT_MS)
@@ -23,7 +23,32 @@ function normalizeEnvString (value) {
   return String(value || '').trim().replace(/^['"]|['"]$/g, '')
 }
 
+function parseEmailAddress (value) {
+  const text = normalizeEnvString(value)
+  const match = text.match(/^(.*?)\s*<([^>]+)>$/)
+
+  if (!match) return { email: text }
+
+  const name = match[1].trim().replace(/^['"]|['"]$/g, '')
+  return {
+    email: match[2].trim(),
+    ...(name ? { name } : {})
+  }
+}
+
 function getEnvEmailConfig () {
+  const brevoApiKey = normalizeEnvString(process.env.BREVO_API_KEY)
+  const brevoFrom = normalizeEnvString(process.env.BREVO_FROM || process.env.EMAIL_FROM || process.env.SMTP_FROM)
+
+  if (brevoApiKey && brevoFrom) {
+    return {
+      provider: 'brevo',
+      apiKey: brevoApiKey,
+      from: brevoFrom,
+      timeoutMs: getEmailTimeoutMs()
+    }
+  }
+
   const user = normalizeEnvString(process.env.SMTP_USER || process.env.EMAIL_USER)
   const pass = normalizeEmailPassword(process.env.SMTP_PASS || process.env.EMAIL_PASS)
 
@@ -96,6 +121,39 @@ function createTransporter (config) {
   })
 }
 
+async function sendWithBrevo (config, entry) {
+  if (typeof fetch !== 'function') {
+    throw new Error('Brevo email requires a Node.js runtime with fetch support.')
+  }
+
+  const response = await withTimeout(
+    fetch('https://api.brevo.com/v3/smtp/email', {
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'api-key': config.apiKey,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        sender: parseEmailAddress(config.from),
+        to: [{ email: entry.to }],
+        subject: entry.subject,
+        textContent: entry.body
+      })
+    }),
+    config.timeoutMs,
+    `Email send timed out after ${config.timeoutMs}ms`
+  )
+
+  if (!response.ok) {
+    let detail = ''
+    try {
+      detail = await response.text()
+    } catch (_) {}
+    throw new Error(`Brevo API returned ${response.status}${detail ? `: ${detail}` : ''}`)
+  }
+}
+
 function withTimeout (promise, timeoutMs, message) {
   return Promise.race([
     promise,
@@ -124,17 +182,21 @@ async function sendEmail (entry) {
   }
 
   try {
-    const transporter = createTransporter(config)
-    await withTimeout(
-      transporter.sendMail({
-        from: config.from,
-        to: entry.to,
-        subject: entry.subject,
-        text: entry.body
-      }),
-      config.timeoutMs,
-      `Email send timed out after ${config.timeoutMs}ms`
-    )
+    if (config.provider === 'brevo') {
+      await sendWithBrevo(config, entry)
+    } else {
+      const transporter = createTransporter(config)
+      await withTimeout(
+        transporter.sendMail({
+          from: config.from,
+          to: entry.to,
+          subject: entry.subject,
+          text: entry.body
+        }),
+        config.timeoutMs,
+        `Email send timed out after ${config.timeoutMs}ms`
+      )
+    }
     const logPath = writeLog(entry, 'EMAIL SENT')
     return { sent: true, simulated: false, logPath }
   } catch (error) {

--- a/tests/unit/email-service.test.js
+++ b/tests/unit/email-service.test.js
@@ -1,14 +1,17 @@
 describe('emailService', () => {
   const originalEnv = { ...process.env }
+  const originalFetch = global.fetch
 
   beforeEach(() => {
     jest.resetModules()
     jest.clearAllMocks()
     process.env = { ...originalEnv }
+    global.fetch = originalFetch
   })
 
   afterAll(() => {
     process.env = originalEnv
+    global.fetch = originalFetch
   })
 
   function loadService ({ nodeEnv = 'test', env = {}, dbReadyState = 0, dbSettings = null } = {}) {
@@ -89,9 +92,9 @@ describe('emailService', () => {
         user: 'sender@example.test',
         pass: 'secret'
       },
-      connectionTimeout: 10000,
-      greetingTimeout: 10000,
-      socketTimeout: 10000
+      connectionTimeout: 30000,
+      greetingTimeout: 30000,
+      socketTimeout: 30000
     })
     expect(createTransport.mock.results[0].value.sendMail).toHaveBeenCalledWith({
       from: 'no-reply@example.test',
@@ -130,9 +133,9 @@ describe('emailService', () => {
     expect(findOne).toHaveBeenCalledWith({ name: 'default', enabled: true })
     expect(createTransport).toHaveBeenCalledWith(expect.objectContaining({
       host: 'smtp.db.test',
-      connectionTimeout: 10000,
-      greetingTimeout: 10000,
-      socketTimeout: 10000,
+      connectionTimeout: 30000,
+      greetingTimeout: 30000,
+      socketTimeout: 30000,
       auth: {
         user: 'db@example.test',
         pass: 'db-secret'
@@ -164,13 +167,58 @@ describe('emailService', () => {
         user: 'sender@gmail.com',
         pass: 'secret'
       },
-      connectionTimeout: 10000,
-      greetingTimeout: 10000,
-      socketTimeout: 10000
+      connectionTimeout: 30000,
+      greetingTimeout: 30000,
+      socketTimeout: 30000
     })
     expect(appendFileSync).toHaveBeenCalledWith(
       expect.stringContaining('email-log.txt'),
       expect.stringContaining('TO: lecturer@wits.ac.za | SUBJECT: Subject'),
+      'utf8'
+    )
+  })
+
+  it('sends real mail with Brevo API configuration outside tests', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: jest.fn().mockResolvedValue('')
+    })
+    const { service, createTransport, appendFileSync } = loadService({
+      nodeEnv: 'development',
+      env: {
+        BREVO_API_KEY: 'xkeysib-test-key',
+        EMAIL_FROM: 'Consultation Scheduler <no-reply@example.test>'
+      }
+    })
+
+    await service.sendNotification(
+      { email: 'lecturer@wits.ac.za', emailNotifications: true },
+      'New booking',
+      'A student booked your slot'
+    )
+
+    expect(createTransport).not.toHaveBeenCalled()
+    expect(global.fetch).toHaveBeenCalledWith('https://api.brevo.com/v3/smtp/email', {
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'api-key': 'xkeysib-test-key',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        sender: {
+          email: 'no-reply@example.test',
+          name: 'Consultation Scheduler'
+        },
+        to: [{ email: 'lecturer@wits.ac.za' }],
+        subject: 'New booking',
+        textContent: 'A student booked your slot'
+      })
+    })
+    expect(appendFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('email-log.txt'),
+      expect.stringContaining('TO: lecturer@wits.ac.za | SUBJECT: New booking'),
       'utf8'
     )
   })

--- a/tests/unit/passwordreset.test.js
+++ b/tests/unit/passwordreset.test.js
@@ -16,6 +16,7 @@ jest.mock('../../src/utils/emailService', () => ({
 
 const validEmail = 'jane@student.wits.ac.za'
 const userId = 'user123'
+const originalEnv = { ...process.env }
 const makeUser = (overrides = {}) => ({
   _id: userId,
   name: 'Jane',
@@ -25,7 +26,14 @@ const makeUser = (overrides = {}) => ({
   ...overrides
 })
 
-beforeEach(() => jest.clearAllMocks())
+beforeEach(() => {
+  jest.clearAllMocks()
+  process.env = { ...originalEnv }
+})
+
+afterAll(() => {
+  process.env = originalEnv
+})
 
 // ─── FORGOT PASSWORD ──────────────────────────────────────────────────────────
 describe('POST /api/auth/forgot-password', () => {
@@ -41,7 +49,17 @@ describe('POST /api/auth/forgot-password', () => {
     PasswordResetToken.deleteMany.mockResolvedValue({})
     PasswordResetToken.create.mockResolvedValue({})
 
-    const res = await request(app).post('/api/auth/forgot-password').send({ email: user.email })
+    delete process.env.FRONTEND_URL
+    delete process.env.PUBLIC_URL
+    delete process.env.APP_BASE_URL
+    delete process.env.RENDER_EXTERNAL_URL
+
+    const res = await request(app)
+      .post('/api/auth/forgot-password')
+      .set('x-forwarded-proto', 'https')
+      .set('x-forwarded-host', 'synchro-yb1b.onrender.com')
+      .send({ email: user.email })
+
     expect(res.status).toBe(200)
     expect(PasswordResetToken.create).toHaveBeenCalledWith(expect.objectContaining({
       userId: user._id,
@@ -51,7 +69,7 @@ describe('POST /api/auth/forgot-password', () => {
     expect(sendPasswordResetEmail).toHaveBeenCalledWith(
       user.email,
       expect.stringMatching(/^\d{6}$/),
-      expect.stringContaining('/reset-password.html?email=')
+      `https://synchro-yb1b.onrender.com/reset-password.html?email=${encodeURIComponent(user.email)}`
     )
   })
 })


### PR DESCRIPTION
## Summary

This PR fixes production email delivery on Render by replacing the blocked SMTP path with Brevo’s HTTPS Transactional Email API.

Render Free blocks outbound SMTP ports, which caused verification and password reset emails to time out. The app now uses Brevo when `BREVO_API_KEY` is configured, while keeping SMTP as a fallback for local/dev or other hosting environments.

## Changes

- Added Brevo API email delivery support via `POST https://api.brevo.com/v3/smtp/email`
- Added support for:
  - `BREVO_API_KEY`
  - `BREVO_FROM`
  - existing fallback `EMAIL_FROM`
- Preserved existing SMTP/Nodemailer support as fallback
- Fixed password reset links so production emails use the deployed public URL instead of `localhost`
- Added tests for:
  - Brevo API email delivery
  - Render-style password reset links

## Required Render Environment Variables

```env
BREVO_API_KEY=xkeysib-...
BREVO_FROM=Consultation Scheduler <verified-sender@example.com>
PUBLIC_URL=https://synchro-yb1b.onrender.com